### PR TITLE
Change collection_prep installation to GitHub URL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,7 +138,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install ansible-core ansible-lint pyyaml
-          pip install 'ansible-network/collection_prep@1.1.1'
+          # pip install 'ansible-network/collection_prep@1.1.1'
+          pip install git+https://github.com/ansible-network/collection_prep.git@v1.1.1
 
       - name: Update documentation
         run: collection_prep_add_docs


### PR DESCRIPTION
Updated the installation command for the collection_prep package to use a GitHub URL instead of a pip package reference.