### PR TITLE
Adding change used on lab for admin password.

### DIFF
--- a/roles/platform_satellite_config/README.md
+++ b/roles/platform_satellite_config/README.md
@@ -31,6 +31,7 @@ Variables below are referenced by the role task files under `tasks/`. Defaults a
 |----------|-------------|----------|---------|
 | `platform_satellite_config_admin_username` | Satellite administrator username for API and Hammer calls | ✅ | Not defined in role defaults |
 | `platform_satellite_config_admin_password` | Satellite administrator password | ✅ | Not defined in role defaults |
+| `platform_satellite_config_set_admin_password` | When `true`, reset the Satellite admin password with `foreman-rake permissions:reset` before applying settings | ❌ | `false` |
 | `platform_satellite_config_server_url` | Satellite server URL | ❌ | `"https://{{ ansible_fqdn }}"` |
 | `platform_satellite_config_organization` | Satellite organization name or label | ✅ | Not defined in role defaults |
 | `platform_satellite_config_validate_certs` | Whether to validate Satellite TLS certificates | ❌ | Not defined in role defaults |

--- a/roles/platform_satellite_config/README.md
+++ b/roles/platform_satellite_config/README.md
@@ -29,9 +29,9 @@ Variables below are referenced by the role task files under `tasks/`. Defaults a
 
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
-| `platform_satellite_config_admin_username` | Satellite administrator username for API and Hammer calls | ✅ | Not defined in role defaults |
-| `platform_satellite_config_admin_password` | Satellite administrator password | ✅ | Not defined in role defaults |
-| `platform_satellite_config_set_admin_password` | When `true`, reset the Satellite admin password with `foreman-rake permissions:reset` before applying settings | ❌ | `false` |
+| `platform_satellite_config_username` | Satellite administrator username for API and Hammer calls | ✅ | Not defined in role defaults |
+| `platform_satellite_config_password` | Satellite administrator password for API and Hammer calls | ✅ | Not defined in role defaults |
+| `platform_satellite_config_admin_password` | Satellite admin account password. Can be used to update admin's password | ✅ | Not defined in role defaults |
 | `platform_satellite_config_server_url` | Satellite server URL | ❌ | `"https://{{ ansible_fqdn }}"` |
 | `platform_satellite_config_organization` | Satellite organization name or label | ✅ | Not defined in role defaults |
 | `platform_satellite_config_validate_certs` | Whether to validate Satellite TLS certificates | ❌ | Not defined in role defaults |

--- a/roles/platform_satellite_config/tasks/enable_repos.yml
+++ b/roles/platform_satellite_config/tasks/enable_repos.yml
@@ -8,8 +8,8 @@
 
 - name: enable_repos | Enable Red Hat repos
   redhat.satellite.repository_set:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     organization: "{{ platform_satellite_config_organization }}"
     label: "{{ item['label'] }}"

--- a/roles/platform_satellite_config/tasks/manifest.yml
+++ b/roles/platform_satellite_config/tasks/manifest.yml
@@ -9,8 +9,8 @@
 
 - name: manifest | Remove the manifest
   redhat.satellite.subscription_manifest:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     organization: "{{ platform_satellite_config_organization }}"
     state: absent
@@ -19,8 +19,8 @@
 
 - name: manifest | Upload the manifest for Satellite
   redhat.satellite.subscription_manifest:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     organization: "{{ platform_satellite_config_organization }}"
     state: present
@@ -30,8 +30,8 @@
 
 - name: manifest | Refresh the manifest
   redhat.satellite.subscription_manifest:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     organization: "{{ platform_satellite_config_organization }}"
     state: refreshed

--- a/roles/platform_satellite_config/tasks/repo_sync.yml
+++ b/roles/platform_satellite_config/tasks/repo_sync.yml
@@ -4,8 +4,8 @@
     url: "{{ platform_satellite_config_server_url }}/katello/api/organizations/1/products?per_page=500"
     method: GET
     return_content: true
-    user: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    user: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     force_basic_auth: true
     validate_certs: false
   register: platform_satellite_config_products_output
@@ -19,8 +19,8 @@
 
 - name: repo_sync | Sync all repos for enabled products
   redhat.satellite.repository_sync:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     product: "{{ item }}"
     organization: "{{ platform_satellite_config_organization }}"

--- a/roles/platform_satellite_config/tasks/settings.yml
+++ b/roles/platform_satellite_config/tasks/settings.yml
@@ -1,7 +1,11 @@
 ---
-- name: settings | Set password for admin user
-  ansible.builtin.shell: "foreman-rake permissions:reset password={{ platform_satellite_config_admin_password }}"
-
+- name: settings| Set password for admin user
+  ansible.builtin.command:
+    argv:
+      - foreman-rake
+      - permissions:reset
+      - "password={{ platform_satellite_config_admin_password }}"
+  when: platform_satellite_config_set_admin_password | bool
 
 - name: settings | Set Red Hat Satellite Settings
   redhat.satellite.setting:

--- a/roles/platform_satellite_config/tasks/settings.yml
+++ b/roles/platform_satellite_config/tasks/settings.yml
@@ -1,11 +1,12 @@
 ---
-- name: settings| Set password for admin user
+- name: settings | Set password for admin user
   ansible.builtin.command:
     argv:
       - foreman-rake
       - permissions:reset
       - "password={{ platform_satellite_config_admin_password }}"
   when: platform_satellite_config_set_admin_password | bool
+  changed_when: false
 
 - name: settings | Set Red Hat Satellite Settings
   redhat.satellite.setting:

--- a/roles/platform_satellite_config/tasks/settings.yml
+++ b/roles/platform_satellite_config/tasks/settings.yml
@@ -1,16 +1,31 @@
 ---
-- name: settings| Set password for admin user
-  ansible.builtin.command:
-    argv:
-      - foreman-rake
-      - permissions:reset
-      - "password={{ platform_satellite_config_admin_password }}"
-  when: platform_satellite_config_set_admin_password | bool
+- name: settings | Validate admin user password
+  ansible.builtin.uri: 
+    url: "{{ platform_satellite_config_server_url }}/api/status"
+    user: admin
+    password: "{{ platform_satellite_config_admin_password }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: 200
+  register: admin_auth
+  failed_when: false
+  changed_when: false
+
+- name: settings | Set password for admin user
+  redhat.satellite.user:
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
+    server_url: "{{ platform_satellite_config_server_url }}"
+    login: admin
+    user_password: "{{ platform_satellite_config_admin_password }}"
+    validate_certs: "{{ platform_satellite_config_validate_certs }}"
+    state: present
+  when: admin_auth.status != 200
 
 - name: settings | Set Red Hat Satellite Settings
   redhat.satellite.setting:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     name: "{{ item['name'] }}"
     value: "{{ item['value'] }}"
@@ -20,8 +35,8 @@
 - name: settings | Disable subscription connection for disconnected satellite
   when: platform_satellite_config_rhn_connected is false
   redhat.satellite.setting:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     name: "subscription_connection_enabled"
     value: "No"
@@ -29,8 +44,8 @@
 
 - name: settings | Create HTTP proxy object
   redhat.satellite.http_proxy:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     name: "{{ platform_satellite_config_proxy_server }}"
     url: "{{ platform_satellite_config_proxy_scheme }}://{{ platform_satellite_config_proxy_server }}:{{ platform_satellite_config_proxy_port }}"
@@ -41,8 +56,8 @@
 
 - name: settings | Set HTTP proxy setting
   redhat.satellite.setting:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     name: content_default_http_proxy
     value: "{{ platform_satellite_config_proxy_server }}"
@@ -66,8 +81,8 @@
 
 - name: settings | Create content credential for disconnected satellite
   redhat.satellite.content_credential:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     organization: "{{ platform_satellite_config_organization }}"
     name: "{{ platform_satellite_config_connected_fqdn }}"
@@ -78,8 +93,8 @@
 
 - name: settings | Get ID of content credential for cdn
   redhat.satellite.content_credential:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     organization: "{{ platform_satellite_config_organization }}"
     name: "{{ platform_satellite_config_connected_fqdn }}"

--- a/roles/platform_satellite_config/tasks/settings.yml
+++ b/roles/platform_satellite_config/tasks/settings.yml
@@ -1,13 +1,13 @@
 ---
 - name: settings | Validate admin user password
-  ansible.builtin.uri: 
+  ansible.builtin.uri:
     url: "{{ platform_satellite_config_server_url }}/api/status"
     user: admin
     password: "{{ platform_satellite_config_admin_password }}"
     force_basic_auth: true
     validate_certs: false
     status_code: 200
-  register: admin_auth
+  register: platform_satellite_config_admin_auth
   failed_when: false
   changed_when: false
 
@@ -20,7 +20,7 @@
     user_password: "{{ platform_satellite_config_admin_password }}"
     validate_certs: "{{ platform_satellite_config_validate_certs }}"
     state: present
-  when: admin_auth.status != 200
+  when: platform_satellite_config_admin_auth.status != 200
 
 - name: settings | Set Red Hat Satellite Settings
   redhat.satellite.setting:

--- a/roles/platform_satellite_config/tasks/settings.yml
+++ b/roles/platform_satellite_config/tasks/settings.yml
@@ -1,4 +1,8 @@
 ---
+- name: settings | Set password for admin user
+  ansible.builtin.shell: "foreman-rake permissions:reset password={{ platform_satellite_config_admin_password }}"
+
+
 - name: settings | Set Red Hat Satellite Settings
   redhat.satellite.setting:
     username: "{{ platform_satellite_config_admin_username }}"

--- a/roles/platform_satellite_config/tasks/third_party_products.yml
+++ b/roles/platform_satellite_config/tasks/third_party_products.yml
@@ -37,8 +37,8 @@
 
 - name: third_party_products | Upload custom repos"
   redhat.satellite.content_upload:
-    username: "{{ platform_satellite_config_admin_username }}"
-    password: "{{ platform_satellite_config_admin_password }}"
+    username: "{{ platform_satellite_config_username }}"
+    password: "{{ platform_satellite_config_password }}"
     server_url: "{{ platform_satellite_config_server_url }}"
     organization: "{{ platform_satellite_config_organization }}"
     src: "{{ platform_satellite_config_custom_repo_dest }}/{{ item.1 }}"

--- a/roles/platform_satellite_install/README.md
+++ b/roles/platform_satellite_install/README.md
@@ -36,6 +36,7 @@ Variables below are referenced by the role task files under `tasks/`. Defaults a
 | `platform_satellite_install_satellite_min_cpu_count` | Minimum required vCPU count and input to the Satellite tuning profile template | ❌ | `4` |
 | `platform_satellite_install_satellite_rhn_connected` | When `true`, validate RHSM credentials during preliminary checks | ❌ | `false` |
 | `platform_satellite_install_satellite_rhn_org_id` | RHSM organization ID used for host registration | ✅* | `""` |
+| `platform_satellite_install_satellite_admin_password` | Password to set for admin user when installing Satellite | ✅ | `""` |
 | `platform_satellite_install_satellite_rhn_activation_key` | RHSM activation key used for host registration | ✅* | `""` |
 | `platform_satellite_install_satellite_rhn_repos` | RHSM repository IDs enabled after registration | ❌ | See `defaults/main.yml` |
 | `platform_satellite_install_satellite_timezone` | System timezone set before RHSM registration | ❌ | `"UTC"` |

--- a/roles/platform_satellite_install/tasks/install_satellite.yml
+++ b/roles/platform_satellite_install/tasks/install_satellite.yml
@@ -26,6 +26,14 @@
       ansible.builtin.command: "satellite-installer --scenario satellite --tuning {{ platform_satellite_install_tuning_profile }}"
       changed_when: true
 
+    - name: install_satellite | Set password for admin user
+      ansible.builtin.command:
+        argv:
+          - foreman-rake
+          - permissions:reset
+          - "password={{ platform_satellite_install_satellite_admin_password }}"
+      changed_when: true
+
 - name: install_satellite | Ensure successful installation
   ansible.builtin.command: satellite-maintain service status
   register: platform_satellite_install_satellite_status


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why (1–3 sentences). -->
Add a play to set the password for admin user. Currently the way it is used the user wouldn't have it automated and would need to find the value created after the install. 

## Related issues

<!-- Link related work. Examples: Fixes #123, Relates to #456 -->
Derives from #159 
-

## Type of change

<!-- Mark all that apply. -->

- [X] New or updated collection role
- [ ] New or updated Molecule scenario (`extensions/molecule/`)
- [ ] CI / GitHub Actions workflow
- [ ] Scripts or developer tooling
- [ ] Documentation only
- [ ] Bug fix
- [ ] Other (describe below)

## Collection impact

<!-- List the main paths touched so reviewers know where to focus. -->

| Area | Path(s) |
| --- | --- |
| Role(s) | platform_satellite_config |
| Molecule scenario(s) | <!-- e.g. extensions/molecule/integration_satellite_content_view_create --> |
| Other | <!-- e.g. scripts/verify_readme.py, .github/workflows/main.yml --> |

## Test plan

<!-- Describe how you validated this change. Check all that apply. -->

- [ ] Reviewed diff locally
- [ ] `ansible-lint` passes (if Ansible content changed)
- [x] README format check passes (if a role README changed):

  ```bash
  python scripts/verify_readme.py roles/<role>/README.md \
    --template docs/templates/role_readme_format_template.md
  ```

- [ ] Molecule scenario run (if applicable):

  ```bash
  cd extensions/molecule
  ln -sfn . molecule
  molecule test -s <scenario>
  ```

- [ ] CI checks pass on this PR

**Notes / commands run:**

<!-- Paste relevant command output or manual test steps. -->
When running the play on my lab environment, it was able to change the password regardless if it was known and was idempotent. ~~We can change it to have a when if we would like it to only run when a user wants it set.~~ This is set to use a when and will only be ran if that value is true. I also would like this to be up to discussion as well as I want this piece to be as automated as possible.

## Release notes

<!-- Optional user-facing note for a changelog entry. Leave blank if not applicable. -->

-

## Checklist

- [ ] Role README follows `docs/templates/role_readme_format_template.md` (for role changes)
- [ ] Discussed with the team (for new roles or significant design changes)
- [X] No secrets, credentials, or environment-specific values committed
- [ ] Breaking changes or migration steps documented above (if any)
