### PR TITLE
59 migrate the aap config role over to GitHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,9 +145,11 @@ jobs:
   readme-format-check:
     name: README Format Verification
     runs-on: ubuntu-latest
+    # Runs on PRs for visibility; informational only until added to pr-gate.
     if: |
-      github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.run_readme_verification == 'true'
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.event.inputs.run_readme_verification == 'true')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -158,9 +160,28 @@ jobs:
           python-version: '3.11'
 
       - name: Run README format verification
+        id: readme_verify
+        # Informational only for now; enable PR gate check when ready to enforce.
+        continue-on-error: true
         run: |
-          set -o pipefail
-          python scripts/verify_readme.py --template docs/templates/role_readme_format_template.md 2>&1 | tee readme-verification.txt
+          set +e
+          python scripts/verify_readme.py --template docs/templates/role_readme_format_template.md \
+            > readme-verification.txt 2>&1
+          exit_code=$?
+          cat readme-verification.txt
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit "$exit_code"
+
+      - name: Add README verification summary
+        if: always()
+        run: |
+          {
+            echo "## README Format Verification"
+            echo
+            echo '```text'
+            cat readme-verification.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload README verification report
         if: always()
@@ -168,6 +189,8 @@ jobs:
         with:
           name: readme-verification-report
           path: readme-verification.txt
+          if-no-files-found: error
+          retention-days: 30
 
   # Testing stage
   discover-molecule-scenarios:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: false
         type: boolean
+      run_integration_aap_configuration:
+        description: "Run integration_aap_configuration"
+        required: false
+        default: false
+        type: boolean
       run_integration_rhel_cron_full_special:
         description: "Run integration_rhel_cron_full_special"
         required: false
@@ -213,6 +218,7 @@ jobs:
             declare -A checks=(
               [integration_vm_image_management]="${{ github.event.inputs.run_integration_vm_image_management }}"
               [integration_aap_build_ee]="${{ github.event.inputs.run_integration_aap_build_ee }}"
+              [integration_aap_configuration]="${{ github.event.inputs.run_integration_aap_configuration }}"
               [integration_rhel_cron_full_special]="${{ github.event.inputs.run_integration_rhel_cron_full_special }}"
               [integration_rhel_cron_full_special_removal]="${{ github.event.inputs.run_integration_rhel_cron_full_special_removal }}"
               [integration_rhel_cron_single_special]="${{ github.event.inputs.run_integration_rhel_cron_single_special }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
   readme-format:
     name: README Format Verification
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,10 +35,27 @@ jobs:
           python-version: '3.11'
 
       - name: Run README format verification
-        run: |
-          set -o pipefail
-          python scripts/verify_readme.py 2>&1 | tee readme-verification.txt
+        id: readme_verify
+        # Informational only for now; add to all_green when ready to enforce.
         continue-on-error: true
+        run: |
+          set +e
+          python scripts/verify_readme.py > readme-verification.txt 2>&1
+          exit_code=$?
+          cat readme-verification.txt
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit "$exit_code"
+
+      - name: Add README verification summary
+        if: always()
+        run: |
+          {
+            echo "## README Format Verification"
+            echo
+            echo '```text'
+            cat readme-verification.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload README verification report
         if: always()
@@ -45,6 +63,8 @@ jobs:
         with:
           name: readme-verification-report
           path: readme-verification.txt
+          if-no-files-found: error
+          retention-days: 30
   sanity:
     uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@main
   unit-galaxy:

--- a/extensions/molecule/integration_aap_configuration/.gitignore
+++ b/extensions/molecule/integration_aap_configuration/.gitignore
@@ -1,0 +1,1 @@
+mock_collections/

--- a/extensions/molecule/integration_aap_configuration/README.md
+++ b/extensions/molecule/integration_aap_configuration/README.md
@@ -1,0 +1,56 @@
+# Molecule scenario: integration_aap_configuration
+
+This scenario validates wiring for the `infra.ado.aap_configuration` role in
+the normalized extension-level Molecule layout.
+
+## Scenario flow
+
+1. `prepare`
+2. `converge`
+3. `idempotence`
+4. `verify`
+5. `destroy` (via `destroy_sequence`)
+
+## Playbook mapping
+
+Scenario `molecule.yml` points to shared playbooks in
+`extensions/molecule/utils/playbooks`:
+
+- `prepare`: `aap_configuration_prepare.yml`
+- `converge`: `aap_configuration_converge.yml`
+- `verify`: `aap_configuration_verify.yml`
+- `destroy`: `aap_configuration_destroy.yml`
+
+## Run
+
+Install the collection from the repository root, then run the scenario from
+`extensions/molecule`:
+
+```bash
+cd /path/to/ado
+ansible-galaxy collection install . --force -p ~/.ansible/collections
+export ANSIBLE_COLLECTIONS_PATH="$HOME/.ansible/collections:${ANSIBLE_COLLECTIONS_PATH:-}"
+
+cd extensions/molecule
+molecule test -s integration_aap_configuration
+```
+
+## Default (mock dispatch) mode
+
+By default, `prepare` installs a mock `infra.aap_configuration.dispatch` role under
+`integration_aap_configuration/mock_collections`. The converge step validates that
+playbook-side config files are copied into the role and that the wrapper invokes the
+dispatcher with `aap_configuration_config_path`.
+
+## Live-check mode
+
+To run against the real `infra.aap_configuration.dispatch` role, install that
+collection from Ansible Galaxy and enable live checks:
+
+```bash
+export AAP_CONFIGURATION_ENABLE_LIVE_CHECKS=true
+molecule test -s integration_aap_configuration
+```
+
+Provide valid AAP configuration YAML files under
+`extensions/molecule/utils/playbooks/configs/` before running live checks.

--- a/extensions/molecule/integration_aap_configuration/TEST.md
+++ b/extensions/molecule/integration_aap_configuration/TEST.md
@@ -1,0 +1,38 @@
+# TEST: integration_aap_configuration
+
+## Purpose
+
+Validate extension-level Molecule scenario wiring for
+`infra.ado.aap_configuration`.
+
+## Sequence
+
+- `prepare`
+- `converge`
+- `idempotence`
+- `verify`
+- `destroy`
+
+## Notes
+
+- `prepare` creates a mock `infra.aap_configuration.dispatch` collection and a
+  sample config file under `utils/playbooks/configs/`.
+- `converge` runs the wrapper role against localhost using the mock dispatcher
+  by default.
+- `verify` checks copied config files, mock dispatch invocation, and README
+  format via `scripts/verify_readme.py`.
+- `destroy` removes fixtures from the playbook configs directory, role configs
+  directories, and the scenario `mock_collections` directory.
+- Set `AAP_CONFIGURATION_ENABLE_LIVE_CHECKS=true` to skip mock-dispatch
+  assertions and run against a real `infra.aap_configuration` installation.
+
+## Run
+
+```bash
+cd /path/to/ado
+ansible-galaxy collection install . --force -p ~/.ansible/collections
+export ANSIBLE_COLLECTIONS_PATH="$HOME/.ansible/collections:${ANSIBLE_COLLECTIONS_PATH:-}"
+
+cd extensions/molecule
+molecule test -s integration_aap_configuration
+```

--- a/extensions/molecule/integration_aap_configuration/molecule.yml
+++ b/extensions/molecule/integration_aap_configuration/molecule.yml
@@ -1,0 +1,26 @@
+---
+platforms:
+  - name: na
+
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_SCENARIO_DIRECTORY}/../../../roles:${ANSIBLE_ROLES_PATH}"
+    ANSIBLE_COLLECTIONS_PATH: "${MOLECULE_SCENARIO_DIRECTORY}/mock_collections:${ANSIBLE_COLLECTIONS_PATH}"
+  playbooks:
+    prepare: ../utils/playbooks/aap_configuration_prepare.yml
+    converge: ../utils/playbooks/aap_configuration_converge.yml
+    verify: ../utils/playbooks/aap_configuration_verify.yml
+    destroy: ../utils/playbooks/aap_configuration_destroy.yml
+  config_options:
+    defaults:
+      collections_path: "${ANSIBLE_COLLECTIONS_PATH}"
+
+scenario:
+  test_sequence:
+    - prepare
+    - converge
+    - idempotence
+    - verify
+  destroy_sequence:
+    - destroy

--- a/extensions/molecule/utils/files/aap_configuration_mock_dispatch_tasks.yml
+++ b/extensions/molecule/utils/files/aap_configuration_mock_dispatch_tasks.yml
@@ -1,0 +1,14 @@
+---
+- name: Record dispatcher invocation
+  ansible.builtin.copy:
+    dest: "{{ aap_configuration_config_path }}/dispatch-invoked.yml"
+    content: |
+      aap_configuration_dispatch_invoked: true
+      aap_configuration_config_path: "{{ aap_configuration_config_path }}"
+    mode: "0644"
+
+- name: Assert config path was provided
+  ansible.builtin.assert:
+    that:
+      - aap_configuration_config_path is defined
+      - aap_configuration_config_path | length > 0

--- a/extensions/molecule/utils/playbooks/aap_configuration_converge.yml
+++ b/extensions/molecule/utils/playbooks/aap_configuration_converge.yml
@@ -1,0 +1,32 @@
+---
+- name: Converge integration_aap_configuration scenario
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    aap_configuration_enable_live_checks: >-
+      {{
+        (lookup('env', 'AAP_CONFIGURATION_ENABLE_LIVE_CHECKS')
+        | default('false', true)) | bool
+      }}
+
+  tasks:
+    - name: Explain live-check toggle
+      ansible.builtin.debug:
+        msg: >-
+          aap_configuration uses a mock infra.aap_configuration.dispatch role by
+          default in Molecule. Set AAP_CONFIGURATION_ENABLE_LIVE_CHECKS=true and
+          install the real infra.aap_configuration collection to exercise live
+          dispatch against an AAP controller.
+      when: not aap_configuration_enable_live_checks
+
+    - name: Run aap_configuration role with mock dispatch
+      ansible.builtin.include_role:
+        name: infra.ado.aap_configuration
+      when: not aap_configuration_enable_live_checks
+
+    - name: Run aap_configuration role with live dispatch
+      ansible.builtin.include_role:
+        name: infra.ado.aap_configuration
+      when: aap_configuration_enable_live_checks

--- a/extensions/molecule/utils/playbooks/aap_configuration_destroy.yml
+++ b/extensions/molecule/utils/playbooks/aap_configuration_destroy.yml
@@ -1,0 +1,31 @@
+---
+- name: Destroy integration_aap_configuration scenario
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    repo_root: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../.."
+    aap_configuration_scenario_dir: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    aap_configuration_test_root: "{{ aap_configuration_scenario_dir }}"
+    aap_configuration_role_configs_candidates:
+      - "{{ repo_root }}/roles/aap_configuration/configs"
+      - "{{ repo_root }}/.ansible/collections/ansible_collections/infra/ado/roles/aap_configuration/configs"
+      - "{{ lookup('env', 'HOME') }}/.ansible/collections/ansible_collections/infra/ado/roles/aap_configuration/configs"
+
+  tasks:
+    - name: Remove playbook configs fixture
+      ansible.builtin.file:
+        path: "{{ playbook_dir }}/configs/aap_configuration.example.yml"
+        state: absent
+
+    - name: Remove role configs directories created during converge
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ aap_configuration_role_configs_candidates }}"
+
+    - name: Remove mock collections directory
+      ansible.builtin.file:
+        path: "{{ aap_configuration_test_root }}/mock_collections"
+        state: absent

--- a/extensions/molecule/utils/playbooks/aap_configuration_prepare.yml
+++ b/extensions/molecule/utils/playbooks/aap_configuration_prepare.yml
@@ -1,0 +1,67 @@
+---
+- name: Prepare integration_aap_configuration scenario
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    aap_configuration_scenario_dir: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    aap_configuration_test_root: "{{ aap_configuration_scenario_dir }}"
+    aap_configuration_mock_collection_root: >-
+      {{ aap_configuration_test_root }}/mock_collections/ansible_collections/infra/aap_configuration
+    aap_configuration_mock_dispatch_tasks: >-
+      {{ aap_configuration_mock_collection_root }}/roles/dispatch/tasks/main.yml
+
+  tasks:
+    - name: Ensure integration test directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ aap_configuration_test_root }}"
+        - "{{ aap_configuration_mock_collection_root }}/roles/dispatch/tasks"
+        - "{{ aap_configuration_mock_collection_root }}/roles/dispatch/meta"
+        - "{{ playbook_dir }}/configs"
+
+    - name: Create mock infra.aap_configuration collection metadata
+      ansible.builtin.copy:
+        dest: "{{ aap_configuration_mock_collection_root }}/galaxy.yml"
+        mode: "0644"
+        content: |
+          namespace: infra
+          name: aap_configuration
+          version: 0.0.1
+          readme: README.md
+          authors:
+            - Molecule mock
+          description: Mock collection for aap_configuration Molecule tests
+          license:
+            - GPL-3.0-or-later
+
+    - name: Create mock dispatch role metadata
+      ansible.builtin.copy:
+        dest: "{{ aap_configuration_mock_collection_root }}/roles/dispatch/meta/main.yml"
+        mode: "0644"
+        content: |
+          ---
+          galaxy_info:
+            author: Molecule mock
+            description: Mock dispatch role for aap_configuration Molecule tests
+            license: GPL-3.0-or-later
+            min_ansible_version: "2.16"
+          dependencies: []
+
+    - name: Create mock dispatch role tasks
+      ansible.builtin.copy:
+        src: ../files/aap_configuration_mock_dispatch_tasks.yml
+        dest: "{{ aap_configuration_mock_dispatch_tasks }}"
+        mode: "0644"
+
+    - name: Create example AAP configuration fixture
+      ansible.builtin.copy:
+        dest: "{{ playbook_dir }}/configs/aap_configuration.example.yml"
+        mode: "0644"
+        content: |
+          ---
+          aap_configuration_example_setting: molecule-test

--- a/extensions/molecule/utils/playbooks/aap_configuration_verify.yml
+++ b/extensions/molecule/utils/playbooks/aap_configuration_verify.yml
@@ -1,0 +1,70 @@
+---
+- name: Verify integration_aap_configuration scenario
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    repo_root: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../.."
+    aap_configuration_scenario_dir: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    aap_configuration_test_root: "{{ aap_configuration_scenario_dir }}"
+    aap_configuration_role_configs_candidates:
+      - "{{ repo_root }}/roles/aap_configuration/configs"
+      - "{{ repo_root }}/.ansible/collections/ansible_collections/infra/ado/roles/aap_configuration/configs"
+      - "{{ lookup('env', 'HOME') }}/.ansible/collections/ansible_collections/infra/ado/roles/aap_configuration/configs"
+    aap_configuration_enable_live_checks: >-
+      {{
+        (lookup('env', 'AAP_CONFIGURATION_ENABLE_LIVE_CHECKS')
+        | default('false', true)) | bool
+      }}
+    aap_configuration_readme_path: "{{ repo_root }}/roles/aap_configuration/README.md"
+    aap_configuration_verify_script: "{{ repo_root }}/scripts/verify_readme.py"
+    aap_configuration_readme_template: >-
+      {{ repo_root }}/docs/templates/role_readme_format_template.md
+
+  tasks:
+    - name: Find copied configuration file
+      ansible.builtin.find:
+        paths: "{{ aap_configuration_role_configs_candidates }}"
+        patterns: aap_configuration.example.yml
+        file_type: file
+      register: aap_configuration_verify_config_files
+      when: not aap_configuration_enable_live_checks
+
+    - name: Find mock dispatch marker file
+      ansible.builtin.find:
+        paths: "{{ aap_configuration_role_configs_candidates }}"
+        patterns: dispatch-invoked.yml
+        file_type: file
+      register: aap_configuration_verify_dispatch_markers
+      when: not aap_configuration_enable_live_checks
+
+    - name: Assert wrapper workflow artifacts exist
+      ansible.builtin.assert:
+        that:
+          - aap_configuration_verify_config_files.matched | int >= 1
+          - aap_configuration_verify_dispatch_markers.matched | int >= 1
+        fail_msg: >-
+          Expected copied config and dispatch marker under one of:
+          {{ aap_configuration_role_configs_candidates | join(', ') }}.
+      when: not aap_configuration_enable_live_checks
+
+    - name: Verify role README format with verify_readme.py
+      ansible.builtin.command:
+        argv:
+          - python
+          - "{{ aap_configuration_verify_script }}"
+          - "{{ aap_configuration_readme_path }}"
+          - --template
+          - "{{ aap_configuration_readme_template }}"
+        chdir: "{{ repo_root }}"
+      register: aap_configuration_verify_readme
+      changed_when: false
+
+    - name: Fail when README verification fails
+      ansible.builtin.fail:
+        msg: >-
+          README verification failed for {{ aap_configuration_readme_path }}:
+          {{ aap_configuration_verify_readme.stdout }}
+          {{ aap_configuration_verify_readme.stderr }}
+      when: aap_configuration_verify_readme.rc != 0

--- a/extensions/molecule/utils/playbooks/configs/aap_configuration.example.yml
+++ b/extensions/molecule/utils/playbooks/configs/aap_configuration.example.yml
@@ -1,0 +1,2 @@
+---
+aap_configuration_example_setting: molecule-test

--- a/roles/aap_configuration/README.md
+++ b/roles/aap_configuration/README.md
@@ -110,16 +110,27 @@ Key implementation files:
 
 ## 🧪 Role Molecule Testing
 
-A Molecule scenario is present under `molecule/default` for local testing.
+Use the extension integration scenario at
+`extensions/molecule/integration_aap_configuration`.
 
-Run the role's molecule scenario locally:
+Install the collection and dependencies before running locally:
 
 ```bash
-cd roles/aap_configuration
-molecule test -s default
+cd /path/to/your/git/checkout/ado
+ansible-galaxy collection install . --force -p ~/.ansible/collections
+export ANSIBLE_COLLECTIONS_PATH="$HOME/.ansible/collections:${ANSIBLE_COLLECTIONS_PATH:-}"
 ```
 
-The `molecule/default/molecule.yml` scenario runs a local converge against `localhost` and references `converge.yml` under the scenario.
+Run the integration scenario:
+
+```bash
+cd extensions/molecule
+molecule test -s integration_aap_configuration
+```
+
+By default the scenario uses a mock `infra.aap_configuration.dispatch` role.
+Set `AAP_CONFIGURATION_ENABLE_LIVE_CHECKS=true` to run against a real
+`infra.aap_configuration` installation.
 
 ## 📁 Role Structure
 
@@ -133,12 +144,6 @@ roles/
    │  └─ main.yml
    ├─ meta/
    │  └─ main.yml
-   ├─ molecule/
-   │  └─ default/
-   │     ├─ converge.yml
-   │     ├─ destroy.yml
-   │     ├─ molecule.yml
-   │     └─ verify.yml
    ├─ tasks/
    │  ├─ dispatch.yml
    │  └─ main.yml

--- a/roles/aap_configuration/README.md
+++ b/roles/aap_configuration/README.md
@@ -1,0 +1,153 @@
+# Role: `infra.ado.aap_configuration`
+
+Collect user-provided AAP configuration files and dispatch them to the upstream `infra.aap_configuration.dispatch` role for processing.
+
+This role provides a lightweight wrapper that centralizes configuration files under the role path and sets the expected `aap_configuration_config_path` when calling the dispatcher.
+
+## Role Author
+
+- Chad Elliott
+- Automation Development Office
+
+## ✅ Role Requirements
+
+- Ansible >= 2.16.0 (declared in `meta/main.yml`)
+- No role dependencies are declared in `meta/main.yml`
+- The upstream `infra.aap_configuration.dispatch` role must be available on the controller or in `ANSIBLE_ROLES_PATH` / `ANSIBLE_COLLECTIONS_PATHS` at runtime
+- Configuration input is supplied as one or more `*.yml` files in a `configs` directory alongside your playbook
+
+### Required collections
+
+Install the following Ansible Galaxy collections before using this role:
+
+```yaml
+collections:
+  - name: ansible.platform
+  - name: ansible.hub
+  - name: ansible.controller
+    version: ">=4.6.0"
+  - name: ansible.eda
+  - name: infra.aap_configuration
+```
+
+Install with the Ansible Galaxy CLI:
+
+```bash
+ansible-galaxy collection install -r requirements.yml
+```
+
+Or install individually, for example:
+
+```bash
+ansible-galaxy collection install ansible.controller:>=4.6.0
+```
+
+### Extends collection
+
+This role extends the `infra.aap_configuration` collection and delegates configuration processing to that collection's dispatcher. For full documentation of available features, variables, examples, and advanced usage, refer to the collection README:
+
+https://galaxy.ansible.com/ui/repo/published/infra/aap_configuration/
+
+## 📦 Role Variables
+
+This role does not define role-specific defaults. Configuration is supplied through YAML files copied from `{{ playbook_dir }}/configs` into `{{ role_path }}/configs` and loaded with `include_vars`.
+
+| Variable | Description |
+|---------|-------------|
+| `aap_configuration_config_path` | Path passed to `infra.aap_configuration.dispatch`. Set automatically to `{{ role_path }}/configs` when the dispatcher role is invoked. |
+| Config file variables | Keys defined in one or more `*.yml` files placed in a `configs` directory next to your playbook. Files matching `*.yml` are copied into the role's `configs` directory and loaded before dispatch runs. |
+
+To customize behavior, provide properly named keys in your config YAML files or wrap this role in a controlling playbook that sets additional variables.
+
+## 🚀 Role Usage
+
+Create a `configs` directory next to your playbook and add one or more `*.yml` files (for example `configs/aap.example.yml`). Then call the role in a playbook.
+
+When the role runs it will:
+
+- Create `roles/aap_configuration/configs` if missing
+- Copy `configs/*.yml` from the playbook tree into the role-local `configs` directory
+- Include variables from those files and invoke `infra.aap_configuration.dispatch` with the copied config path
+
+### Basic usage
+
+```yaml
+- hosts: localhost
+  gather_facts: false
+  roles:
+    - role: infra.ado.aap_configuration
+```
+
+### Example with a config file
+
+Place configuration in `configs/aap.example.yml` next to your playbook:
+
+```yaml
+# configs/aap.example.yml
+# Add keys expected by infra.aap_configuration.dispatch
+```
+
+```yaml
+- hosts: localhost
+  gather_facts: false
+  roles:
+    - role: infra.ado.aap_configuration
+```
+
+### Behavior notes
+
+- Copies YAML files from `{{ playbook_dir }}/configs` into `{{ role_path }}/configs`
+- Loads all variables from the copied config files using `include_vars`
+- Calls the upstream dispatcher role using `include_role`:
+  - role: `infra.aap_configuration.dispatch`
+  - sets `aap_configuration_config_path` to `{{ role_path }}/configs`
+- This role is intentionally lightweight: it acts as a coordinator that delegates the heavy lifting to `infra.aap_configuration.dispatch`. To debug behavior, inspect the copied files under `roles/aap_configuration/configs` and the logs from the upstream dispatcher role.
+
+Key implementation files:
+
+- `tasks/main.yml`: entrypoint that imports `dispatch.yml`
+- `tasks/dispatch.yml`: gathers and copies config files, loads them, and calls the upstream dispatcher
+
+## 🧪 Role Molecule Testing
+
+A Molecule scenario is present under `molecule/default` for local testing.
+
+Run the role's molecule scenario locally:
+
+```bash
+cd roles/aap_configuration
+molecule test -s default
+```
+
+The `molecule/default/molecule.yml` scenario runs a local converge against `localhost` and references `converge.yml` under the scenario.
+
+## 📁 Role Structure
+
+```text
+roles/
+└─ aap_configuration/
+   ├─ README.md
+   ├─ defaults/
+   │  └─ main.yml
+   ├─ handlers/
+   │  └─ main.yml
+   ├─ meta/
+   │  └─ main.yml
+   ├─ molecule/
+   │  └─ default/
+   │     ├─ converge.yml
+   │     ├─ destroy.yml
+   │     ├─ molecule.yml
+   │     └─ verify.yml
+   ├─ tasks/
+   │  ├─ dispatch.yml
+   │  └─ main.yml
+   ├─ tests/
+   │  └─ inventory
+   └─ vars/
+      └─ main.yml
+```
+
+**License:** GPL-3.0-or-later (see `meta/main.yml`)
+
+Open issues or PRs to add configuration examples, expand documentation, or add integration tests. Follow the repository contribution guidelines.

--- a/roles/aap_configuration/defaults/main.yml
+++ b/roles/aap_configuration/defaults/main.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# defaults file for aap_configuration
+
+# defaults file for aap_configuration
+aap_configuration_namespace: "{{ lookup('env', 'AAP_CONFIGURATION_NAMESPACE') }}"
+aap_configuration_secret: "{{ lookup('env', 'AAP_CONFIGURATION_SECRET') }}"
+aap_configuration_configmap: "{{ lookup('env', 'AAP_CONFIGURATION_CONFIGMAP') }}"
+aap_configuration_serviceaccount: "{{ lookup('env', 'AAP_CONFIGURATION_SERVICEACCOUNT') }}"
+aap_configuration_role: "{{ lookup('env', 'AAP_CONFIGURATION_ROLE') }}"
+aap_configuration_rolebinding: "{{ lookup('env', 'AAP_CONFIGURATION_ROLEBINDING') }}"

--- a/roles/aap_configuration/handlers/main.yml
+++ b/roles/aap_configuration/handlers/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# ---
+# defaults file for advanced-cluster-management

--- a/roles/aap_configuration/meta/main.yml
+++ b/roles/aap_configuration/meta/main.yml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+galaxy_info:
+  author: Chad Elliott
+  description: 'A role to configure the (AAP) configuration.'
+  company: Automation Development Office
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: GPL-3.0-or-later
+
+  min_ansible_version: '2.16.0'
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/aap_configuration/tasks/dispatch.yml
+++ b/roles/aap_configuration/tasks/dispatch.yml
@@ -24,9 +24,14 @@
   ansible.builtin.include_vars:
     dir: "{{ role_path }}/configs"
     extensions: ["yml"]
+    ignore_unknown_extensions: true
+
+- name: Capture config path before delegating to upstream dispatch role
+  ansible.builtin.set_fact:
+    aap_configuration_role_config_path: "{{ role_path }}/configs"
 
 - name: Run upstream infra.aap_configuration dispatcher
   ansible.builtin.include_role:
     name: infra.aap_configuration.dispatch
   vars:
-    aap_configuration_config_path: "{{ role_path }}/configs"
+    aap_configuration_config_path: "{{ aap_configuration_role_config_path }}"

--- a/roles/aap_configuration/tasks/dispatch.yml
+++ b/roles/aap_configuration/tasks/dispatch.yml
@@ -1,0 +1,31 @@
+---
+- name: Ensure local configs directory exists
+  ansible.builtin.file:
+    path: "{{ role_path }}/configs"
+    state: directory
+    mode: '0755'
+
+- name: Find configuration files from the user's repo
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/configs"
+    patterns: "*.yml"
+  register: user_configs
+
+- name: Copy user configuration files into role configs directory
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
+    dest: "{{ role_path }}/configs/{{ item.path | basename }}"
+  loop: "{{ user_configs.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+
+- name: Load config vars
+  ansible.builtin.include_vars:
+    dir: "{{ role_path }}/configs"
+    extensions: ["yml"]
+
+- name: Run upstream infra.aap_configuration dispatcher
+  include_role:
+    name: infra.aap_configuration.dispatch
+  vars:
+    aap_configuration_config_path: "{{ role_path }}/configs"

--- a/roles/aap_configuration/tasks/dispatch.yml
+++ b/roles/aap_configuration/tasks/dispatch.yml
@@ -9,13 +9,14 @@
   ansible.builtin.find:
     paths: "{{ playbook_dir }}/configs"
     patterns: "*.yml"
-  register: user_configs
+  register: aap_configuration_user_configs
 
 - name: Copy user configuration files into role configs directory
   ansible.builtin.copy:
     src: "{{ item.path }}"
     dest: "{{ role_path }}/configs/{{ item.path | basename }}"
-  loop: "{{ user_configs.files }}"
+    mode: '0644'
+  loop: "{{ aap_configuration_user_configs.files }}"
   loop_control:
     label: "{{ item.path | basename }}"
 
@@ -25,7 +26,7 @@
     extensions: ["yml"]
 
 - name: Run upstream infra.aap_configuration dispatcher
-  include_role:
+  ansible.builtin.include_role:
     name: infra.aap_configuration.dispatch
   vars:
     aap_configuration_config_path: "{{ role_path }}/configs"

--- a/roles/aap_configuration/tasks/main.yml
+++ b/roles/aap_configuration/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Dispatch ado.aap_configuration workflow
-  import_tasks: dispatch.yml
+  ansible.builtin.import_tasks: dispatch.yml

--- a/roles/aap_configuration/tasks/main.yml
+++ b/roles/aap_configuration/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Dispatch ado.aap_configuration workflow
+  import_tasks: dispatch.yml

--- a/roles/aap_configuration/tests/inventory
+++ b/roles/aap_configuration/tests/inventory
@@ -1,0 +1,2 @@
+#SPDX-License-Identifier: GPL-3.0-or-later
+localhost

--- a/roles/aap_configuration/vars/main.yml
+++ b/roles/aap_configuration/vars/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# ---
+# defaults file for AAP configuration


### PR DESCRIPTION
## Summary

Migrating the role to configure AAP over from the gitlab repo and make any other required changes

## Related issues

Fixes #59 

-

## Type of change

<!-- Mark all that apply. -->

- [x] New or updated collection role
- [x] New or updated Molecule scenario (`extensions/molecule/`)
- [ ] CI / GitHub Actions workflow
- [ ] Scripts or developer tooling
- [ ] Documentation only
- [ ] Bug fix
- [ ] Other (describe below)

## Collection impact


| Area | Path(s) |
| --- | --- |
| Role(s) | roles/aap_configuration |
| Molecule scenario(s) | <extensions/molecule/integration_aap_configuration |
| Other | .github/workflows |

## Test plan

<!-- Describe how you validated this change. Check all that apply. -->

- [x] Reviewed diff locally
- [x] `ansible-lint` passes (if Ansible content changed)
- [x] README format check passes (if a role README changed):

  ```bash
  python scripts/verify_readme.py roles/<role>/README.md \
    --template docs/templates/role_readme_format_template.md
  ```

- [ ] Molecule scenario run (if applicable):

  ```bash
  cd extensions/molecule
  ln -sfn . molecule
  molecule test -s <scenario>
  ```

- [ ] CI checks pass on this PR

**Notes / commands run:**

<!-- Paste relevant command output or manual test steps. -->

## Release notes

<!-- Optional user-facing note for a changelog entry. Leave blank if not applicable. -->

-

## Checklist

- [x] Role README follows `docs/templates/role_readme_format_template.md` (for role changes)
- [x] Discussed with the team (for new roles or significant design changes)
- [x] No secrets, credentials, or environment-specific values committed
- [x] Breaking changes or migration steps documented above (if any)
