### PR TITLE
Enhance `open-changelog-pr` action to improve PR handling by checking…

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -54,7 +54,7 @@ Paths most relevant to the pipeline:
 | [`.github/workflows/tests.yml`](workflows/tests.yml) | Upstream collection CI workflow |
 | [`.github/workflows/security-check.yml`](workflows/security-check.yml) | Standalone security scans |
 | [`.github/workflows/release.yml`](workflows/release.yml) | GitHub Release build and attach |
-| [`.github/workflows/publish-galaxy.yml`](workflows/publish-galaxy.yml) | Manual Ansible Galaxy publish |
+| [`.github/workflows/open-changelog-pr.yml`](workflows/open-changelog-pr.yml) | Manual recovery to open a changelog PR for a release tag |
 | [`.github/actions/build-collection/`](actions/build-collection/) | Shared tag-versioned collection build |
 | [`.github/actions/generate-changelog/`](actions/generate-changelog/) | Compile changelog fragments into `CHANGELOG.rst` |
 | [`.github/actions/open-changelog-pr/`](actions/open-changelog-pr/) | Open a PR to land consumed changelog on `main` |

--- a/.github/actions/open-changelog-pr/action.yml
+++ b/.github/actions/open-changelog-pr/action.yml
@@ -14,6 +14,9 @@ outputs:
   pr_url:
     description: URL of the opened changelog pull request, if created
     value: ${{ steps.open_pr.outputs.pr_url }}
+  pr_opened:
+    description: Whether a changelog pull request was opened or already existed
+    value: ${{ steps.open_pr.outputs.pr_opened }}
 
 runs:
   using: composite
@@ -21,18 +24,33 @@ runs:
     - name: Open changelog pull request to main
       id: open_pr
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         VERSION="${{ inputs.version }}"
         TAG="${{ inputs.tag }}"
         BRANCH="changelog/release-${VERSION}"
+        HEAD_REF="${GITHUB_REPOSITORY_OWNER}:${BRANCH}"
+
+        echo "pr_opened=false" >> "$GITHUB_OUTPUT"
 
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-        git add CHANGELOG.rst changelogs/changelog.yaml changelogs/fragments/
+        git fetch origin main
+
+        if ! git diff --quiet origin/main -- CHANGELOG.rst changelogs/changelog.yaml changelogs/fragments/ \
+          || [ -n "$(git ls-files --others --exclude-standard changelogs/fragments/)" ]; then
+          echo "Changelog changes detected relative to origin/main."
+        else
+          echo "No changelog changes relative to origin/main; skipping PR."
+          exit 0
+        fi
+
+        git add -A CHANGELOG.rst changelogs/changelog.yaml changelogs/fragments/
         if git diff --cached --quiet; then
-          echo "No changelog changes to commit."
+          echo "No staged changelog changes to commit."
           exit 0
         fi
 
@@ -45,17 +63,26 @@ runs:
           git push origin "HEAD:${BRANCH}"
         fi
 
-        EXISTING_PR="$(gh pr list \
-          --repo "${GITHUB_REPOSITORY}" \
-          --head "${BRANCH}" \
-          --base main \
-          --json url \
-          --jq '.[0].url' || true)"
-        if [ -n "${EXISTING_PR}" ]; then
-          echo "Changelog PR already exists: ${EXISTING_PR}"
-          echo "pr_url=${EXISTING_PR}" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
+        for attempt in 1 2 3 4 5; do
+          EXISTING_PR="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --head "${HEAD_REF}" \
+            --base main \
+            --state open \
+            --json url \
+            --jq '.[0].url' 2>/dev/null || true)"
+          if [ -n "${EXISTING_PR}" ]; then
+            echo "Changelog PR already exists: ${EXISTING_PR}"
+            echo "pr_url=${EXISTING_PR}" >> "$GITHUB_OUTPUT"
+            echo "pr_opened=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH}" >/dev/null 2>&1; then
+            break
+          fi
+          echo "Waiting for branch ${BRANCH} to become visible (attempt ${attempt})..."
+          sleep 2
+        done
 
         PR_BODY="Auto-generated changelog for GitHub Release **${TAG}**.
 
@@ -69,3 +96,4 @@ runs:
           --body "${PR_BODY}")"
         echo "Opened changelog PR: ${PR_URL}"
         echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+        echo "pr_opened=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/open-changelog-pr.yml
+++ b/.github/workflows/open-changelog-pr.yml
@@ -1,0 +1,53 @@
+---
+name: Open changelog PR
+
+on: # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to open a changelog PR for (e.g. v1.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open_changelog_pr:
+    name: Open changelog PR for release tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Generate changelog from fragments
+        id: changelog
+        uses: ./.github/actions/generate-changelog
+        with:
+          tag: ${{ github.event.inputs.tag }}
+          consume_fragments: "true"
+
+      - name: Open changelog pull request
+        id: changelog_pr
+        uses: ./.github/actions/open-changelog-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          version: ${{ steps.changelog.outputs.version }}
+          tag: ${{ github.event.inputs.tag }}
+
+      - name: Changelog PR summary
+        if: always()
+        shell: bash
+        run: |
+          if [ "${{ steps.changelog_pr.outputs.pr_opened }}" = "true" ]; then
+            echo "::notice title=Changelog PR::${{ steps.changelog_pr.outputs.pr_url }}"
+          else
+            echo "::error title=Changelog PR::No changelog PR was opened."
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
+          token: ${{ github.token }}
 
       - name: Preview changelog from fragments (pre-release)
         if: github.event.release.prerelease
@@ -72,11 +73,24 @@ jobs:
           fi
 
       - name: Open changelog pull request
-        if: ${{ !github.event.release.prerelease && steps.changelog.outputs.generated == 'true' }}
-        continue-on-error: true
+        if: ${{ !github.event.release.prerelease && steps.changelog.outcome == 'success' }}
+        id: changelog_pr
         uses: ./.github/actions/open-changelog-pr
         env:
           GH_TOKEN: ${{ github.token }}
         with:
           version: ${{ steps.changelog.outputs.version }}
           tag: ${{ github.event.release.tag_name }}
+
+      - name: Changelog PR summary
+        if: ${{ !github.event.release.prerelease && steps.changelog_pr.outcome != 'skipped' }}
+        shell: bash
+        run: |
+          if [ "${{ steps.changelog_pr.outputs.pr_opened }}" = "true" ]; then
+            echo "::notice title=Changelog PR::${{ steps.changelog_pr.outputs.pr_url }}"
+          elif [ "${{ steps.changelog_pr.outcome }}" = "success" ]; then
+            echo "::notice title=Changelog PR::No changelog PR was needed (main already matches the release changelog)."
+          else
+            echo "::error title=Changelog PR::Failed to open changelog PR. Re-run the release workflow or use Actions → Open changelog PR."
+            exit 1
+          fi

--- a/changelogs/fragments/changelog-pr-on-release.yml
+++ b/changelogs/fragments/changelog-pr-on-release.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - >-
-    ci - Open a changelog pull request to ``main`` after official releases instead of
-    pushing directly, so branch protection rules are respected.
+    ci - Fix changelog PR creation after releases by removing the generated-only
+    guard, staging fragment deletions correctly, and improving PR branch handling.


### PR DESCRIPTION
… for existing PRs and ensuring proper branch visibility. Update workflows to reflect changes in changelog PR creation logic and add a summary step for better visibility of PR outcomes. Modify changelog fragment to clarify the new behavior of the changelog PR process after releases.

## Summary

<!-- Briefly describe what changed and why (1–3 sentences). -->

## Related issues

<!-- Link related work. Examples: Fixes #123, Relates to #456 -->

-

## Type of change

<!-- Mark all that apply. -->

- [ ] New or updated collection role
- [ ] New or updated Molecule scenario (`extensions/molecule/`)
- [ ] CI / GitHub Actions workflow
- [ ] Scripts or developer tooling
- [ ] Documentation only
- [ ] Bug fix
- [ ] Other (describe below)

## Collection impact

<!-- List the main paths touched so reviewers know where to focus. -->

| Area | Path(s) |
| --- | --- |
| Role(s) | <!-- e.g. roles/satellite_content_view --> |
| Molecule scenario(s) | <!-- e.g. extensions/molecule/integration_satellite_content_view_create --> |
| Other | <!-- e.g. scripts/verify_readme.py, .github/workflows/main.yml --> |

## Test plan

<!-- Describe how you validated this change. Check all that apply. -->

- [ ] Reviewed diff locally
- [ ] `ansible-lint` passes (if Ansible content changed)
- [ ] README format check passes (if a role README changed):

  ```bash
  python scripts/verify_readme.py roles/<role>/README.md \
    --template docs/templates/role_readme_format_template.md
  ```
  - [ ] Security scan passed if a role was updated

  ```bash
  python3 scripts/security_checks.py roles/<role_name>
  ```

- [ ] Simulate CI changelog validation compared to `main` branch
```bash
python3 scripts/validate_changelog.py --ref main
```

- [ ] Molecule scenario run (if applicable):

  ```bash
  cd extensions/molecule
  ln -sfn . molecule
  molecule test -s <scenario>
  ```

- [ ] CI checks pass on this PR

**Notes / commands run:**

<!-- Paste relevant command output or manual test steps. -->

## Release notes

Add a changelog fragment under `changelogs/fragments/` when the PR modifies existing
roles, plugins, or modules. New plugins/modules and documentation-only changes do not
require a fragment. Use the `skip-changelog` label to bypass validation when no entry is
needed.

Example fragment (`changelogs/fragments/my-change.yml`):

```yaml
minor_changes:
  - my_role - Added support for example configuration.
```

<!-- Optional user-facing note for a changelog entry. Leave blank if not applicable. -->

-

## Checklist

- [ ] Role README follows `docs/templates/role_readme_format_template.md` (for role changes)
- [ ] Discussed with the team (for new roles or significant design changes)
- [ ] No secrets, credentials, or environment-specific values committed
- [ ] Breaking changes or migration steps documented above (if any)
