### PR TITLE
Add ec2_ami_copy module and supporting docs/tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 100
+# E203: black compatibility (whitespace before ':')
+# W503: black compatibility (line break before binary operator)
+extend-ignore = E203, W503
+# Ansible modules keep DOCUMENTATION/EXAMPLES/RETURN above imports.
+per-file-ignores =
+    plugins/modules/*.py: E402

--- a/.github/Developers _Guide.md
+++ b/.github/Developers _Guide.md
@@ -387,7 +387,7 @@ To run `ocp_*` scenarios in CI:
 From the collection root:
 
 ```bash
-ansible-galaxy collection install . --force -p ~/.ansible/collections
+ansible-galaxy collection install . --force --no-deps -p ~/.ansible/collections
 ansible-galaxy collection install ansible.posix community.general containers.podman \
   --force -p ~/.ansible/collections
 export ANSIBLE_COLLECTIONS_PATH="$HOME/.ansible/collections:/usr/share/ansible/collections"
@@ -397,7 +397,9 @@ ln -sfn . molecule
 molecule test -s <scenario_name>
 ```
 
-Per-scenario dependency collections may be declared in
+Use ``--no-deps`` when installing the local collection so Molecule does not
+resolve ``galaxy.yml`` runtime dependencies (for example ``amazon.aws``) from
+Galaxy. Install any scenario-specific collections from
 `extensions/molecule/<scenario>/requirements.yml`.
 
 ## Local development checklist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -438,7 +438,10 @@ jobs:
 
       - name: Install collection from local source
         run: |
-          ansible-galaxy collection install . --force -p ~/.ansible/collections
+          # --no-deps: infra.ado galaxy.yml may declare runtime deps (e.g. amazon.aws)
+          # for modules/sanity; Molecule role scenarios do not need those resolved
+          # from Galaxy and offline/rate-limit failures would break unrelated tests.
+          ansible-galaxy collection install . --force --no-deps -p ~/.ansible/collections
           ansible-galaxy collection install ansible.posix --force -p ~/.ansible/collections
           ansible-galaxy collection install community.general --force -p ~/.ansible/collections
           ansible-galaxy collection install containers.podman --force -p ~/.ansible/collections

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,14 @@ changelogs/.plugin-cache.yaml
 # Ephemeral Molecule symlink created by CI/local runs (ln -sfn . molecule)
 extensions/molecule/molecule
 
+# Local collection install path (keeps collections/requirements.yml)
+collections/ansible_collections/
+
+# Python bytecode / caches from local test runs
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+
 # VSCode
 .vscode/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ infrastructure components consistently.
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against the following Ansible versions: **>=2.16.0**.
+This collection has been tested against the following Ansible versions: **>=2.17.0**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
@@ -44,17 +44,17 @@ PEP440 is the schema used to describe the versions of Ansible.
 
 | Type | Name | Description |
 | --- | --- | --- |
-| Module | [`infra.ado.ec2_ami_copy`](plugins/modules/ec2_ami_copy/README.md) | Copy an AWS AMI from one region to another. |
+| Module | [`infra.ado.ec2_ami_copy`](docs/modules/ec2_ami_copy.md) | Copy an AWS AMI from one region to another. |
 | Role | See [Role documentation](#role-documentation) | Platform automation roles (AAP, OpenShift, RHEL, identity, and more). |
 
 ## Module documentation
 
-Each module keeps its detailed usage, parameters, and examples in its own README.
+Each module keeps its detailed usage, parameters, and examples under `docs/modules/`.
 Use this index as the starting point for operators and automation users.
 
 | Module | Description |
 | --- | --- |
-| [`infra.ado.ec2_ami_copy`](plugins/modules/ec2_ami_copy/README.md) | Copy an AWS AMI from one region to another. |
+| [`infra.ado.ec2_ami_copy`](docs/modules/ec2_ami_copy.md) | Copy an AWS AMI from one region to another. |
 
 ## Role documentation
 

--- a/README.md
+++ b/README.md
@@ -7,25 +7,28 @@ Automation Development Office (`infra.ado`) Ansible collection for building and
 operating platform automation across Ansible Automation Platform, OpenShift,
 RHEL, Satellite, identity services, and supporting tooling.
 
-This collection packages reusable roles used by ADO bootstrap and day-2
-workflows so teams can install, configure, and operate infrastructure components
-consistently.
+This collection packages reusable **roles** and **modules** used by ADO
+bootstrap and day-2 workflows so teams can install, configure, and operate
+infrastructure components consistently.
 
 ## Collection purpose
 
-`infra.ado` provides opinionated Ansible roles for:
+`infra.ado` provides:
 
-- **AAP and bootstrap** — install and configure Ansible Automation Platform,
-  build execution environments, and generate bootstrap playbook repositories and
-  controller objects
-- **OpenShift platform** — operators, namespaces, routes, storage, logging,
-  security, GitOps, virtualization, and related cluster services
-- **Identity** — Red Hat IdM (FreeIPA), Red Hat build of Keycloak (RHBK), LDAP,
-  and OIDC authentication integrations
-- **RHEL and Satellite** — repositories, patching, registration, services,
-  mounts, and Satellite install/content-view management
-- **Observability and devops tooling** — Grafana, Elastic, Kafka, GitLab, Jira,
-  and related helpers
+- **Roles** for opinionated platform automation:
+  - **AAP and bootstrap** — install and configure Ansible Automation Platform,
+    build execution environments, and generate bootstrap playbook repositories
+    and controller objects
+  - **OpenShift platform** — operators, namespaces, routes, storage, logging,
+    security, GitOps, virtualization, and related cluster services
+  - **Identity** — Red Hat IdM (FreeIPA), Red Hat build of Keycloak (RHBK),
+    LDAP, and OIDC authentication integrations
+  - **RHEL and Satellite** — repositories, patching, registration, services,
+    mounts, and Satellite install/content-view management
+  - **Observability and devops tooling** — Grafana, Elastic, Kafka, GitLab,
+    Jira, and related helpers
+- **Modules** for focused tasks that do not fit a role, such as copying an AWS
+  AMI between regions without depending on `community.aws`
 
 <!--start requires_ansible-->
 ## Ansible version compatibility
@@ -36,6 +39,130 @@ Plugins and modules within a collection may be tested with only specific Ansible
 A collection may contain metadata that identifies these versions.
 PEP440 is the schema used to describe the versions of Ansible.
 <!--end requires_ansible-->
+
+## Content index
+
+| Type | Name | Description |
+| --- | --- | --- |
+| Module | [`infra.ado.ec2_ami_copy`](#infraadoec2_ami_copy) | Copy an AWS AMI from one region to another. |
+| Role | See [Role documentation](#role-documentation) | Platform automation roles (AAP, OpenShift, RHEL, identity, and more). |
+
+## Modules
+
+Modules are invoked directly from playbooks or jobs with FQCNs
+(for example `infra.ado.ec2_ami_copy`). Unlike roles, they do not use
+`defaults/main.yml`; pass options as module arguments.
+
+### `infra.ado.ec2_ami_copy`
+
+Copy an Amazon Machine Image (AMI) from a source AWS region into a destination
+region. Returns the new AMI ID. Designed for environments that have
+`amazon.aws` available but **not** `community.aws`.
+
+#### Requirements
+
+- Ansible `>=2.16.0`
+- Collection dependency: [`amazon.aws`](https://docs.ansible.com/ansible/latest/collections/amazon/aws/index.html)
+  (provides AWS authentication helpers used by this module)
+- Python packages on the controller / execution environment: `boto3`, `botocore`
+- IAM permissions in both regions to describe images, copy images, create tags,
+  and (when encrypting) use the target KMS key
+
+Install the dependency alongside this collection, for example:
+
+```yaml
+collections:
+  - name: infra.ado
+  - name: amazon.aws
+```
+
+#### Authentication and region
+
+Use the standard `amazon.aws` credential options (`access_key`, `secret_key`,
+`session_token`, `profile`, environment variables, or instance/role credentials).
+
+- `source_region` — region that currently holds the AMI to copy
+- `region` — destination region where the new AMI is created (from the
+  `amazon.aws` region fragment)
+
+#### Parameters
+
+| Parameter | Required | Default | Description |
+| --- | --- | --- | --- |
+| `source_region` | yes | | Source AWS region of the AMI. |
+| `source_image_id` | yes | | AMI ID in the source region. |
+| `region` | yes* | | Destination AWS region (*via `amazon.aws` region options / env). |
+| `name` | no | `default` | Name for the new AMI. |
+| `description` | no | `""` | Description for the new AMI. |
+| `encrypted` | no | `false` | Encrypt destination EBS snapshots. |
+| `kms_key_id` | no | | KMS key ID/ARN/alias for encryption; account default EBS CMK if omitted when `encrypted=true`. |
+| `copy_image_tags` | no | `false` | Also copy tags from the source AMI. |
+| `tags` | no | | Tags to apply to the new AMI. |
+| `tag_equality` | no | `false` | If `true`, skip copy when a destination AMI already has the same `tags` (requires `tags`). |
+| `wait` | no | `false` | Wait until the AMI is `available`. |
+| `wait_timeout` | no | `600` | Seconds to wait when `wait=true`. |
+
+Supports check mode (`ansible-playbook --check`).
+
+#### Examples
+
+Basic copy and wait for availability:
+
+```yaml
+- name: Copy AMI to us-west-2
+  infra.ado.ec2_ami_copy:
+    source_region: us-east-1
+    region: us-west-2
+    source_image_id: ami-0123456789abcdef0
+    name: my-app-image
+    wait: true
+  register: copied_ami
+
+- name: Show new AMI ID
+  ansible.builtin.debug:
+    var: copied_ami.image_id
+```
+
+Encrypted, tagged, idempotent copy (safe to re-run):
+
+```yaml
+- name: Copy AMI with encryption and tag-based idempotency
+  infra.ado.ec2_ami_copy:
+    source_region: us-east-1
+    region: eu-west-1
+    source_image_id: ami-0123456789abcdef0
+    name: my-app-image
+    description: "Promoted golden image"
+    encrypted: true
+    kms_key_id: alias/aws/ebs
+    tags:
+      Name: my-app-image
+      Environment: prod
+    tag_equality: true
+    wait: true
+    wait_timeout: 1200
+  register: copied_ami
+```
+
+Using an AWS named profile:
+
+```yaml
+- name: Copy AMI with a named profile
+  infra.ado.ec2_ami_copy:
+    profile: my-aws-profile
+    source_region: us-east-1
+    region: us-west-2
+    source_image_id: "{{ source_ami_id }}"
+    name: "{{ ami_name }}"
+    wait: true
+```
+
+#### Return values
+
+| Key | Description |
+| --- | --- |
+| `image_id` | AMI ID of the copied AMI, or the existing match when `tag_equality` skips the copy. |
+| `changed` | `true` when a new copy was started; `false` when an existing AMI was reused. |
 
 ## Role documentation
 

--- a/README.md
+++ b/README.md
@@ -44,125 +44,17 @@ PEP440 is the schema used to describe the versions of Ansible.
 
 | Type | Name | Description |
 | --- | --- | --- |
-| Module | [`infra.ado.ec2_ami_copy`](#infraadoec2_ami_copy) | Copy an AWS AMI from one region to another. |
+| Module | [`infra.ado.ec2_ami_copy`](plugins/modules/ec2_ami_copy/README.md) | Copy an AWS AMI from one region to another. |
 | Role | See [Role documentation](#role-documentation) | Platform automation roles (AAP, OpenShift, RHEL, identity, and more). |
 
-## Modules
+## Module documentation
 
-Modules are invoked directly from playbooks or jobs with FQCNs
-(for example `infra.ado.ec2_ami_copy`). Unlike roles, they do not use
-`defaults/main.yml`; pass options as module arguments.
+Each module keeps its detailed usage, parameters, and examples in its own README.
+Use this index as the starting point for operators and automation users.
 
-### `infra.ado.ec2_ami_copy`
-
-Copy an Amazon Machine Image (AMI) from a source AWS region into a destination
-region. Returns the new AMI ID. Designed for environments that have
-`amazon.aws` available but **not** `community.aws`.
-
-#### Requirements
-
-- Ansible `>=2.16.0`
-- Collection dependency: [`amazon.aws`](https://docs.ansible.com/ansible/latest/collections/amazon/aws/index.html)
-  (provides AWS authentication helpers used by this module)
-- Python packages on the controller / execution environment: `boto3`, `botocore`
-- IAM permissions in both regions to describe images, copy images, create tags,
-  and (when encrypting) use the target KMS key
-
-Install the dependency alongside this collection, for example:
-
-```yaml
-collections:
-  - name: infra.ado
-  - name: amazon.aws
-```
-
-#### Authentication and region
-
-Use the standard `amazon.aws` credential options (`access_key`, `secret_key`,
-`session_token`, `profile`, environment variables, or instance/role credentials).
-
-- `source_region` — region that currently holds the AMI to copy
-- `region` — destination region where the new AMI is created (from the
-  `amazon.aws` region fragment)
-
-#### Parameters
-
-| Parameter | Required | Default | Description |
-| --- | --- | --- | --- |
-| `source_region` | yes | | Source AWS region of the AMI. |
-| `source_image_id` | yes | | AMI ID in the source region. |
-| `region` | yes* | | Destination AWS region (*via `amazon.aws` region options / env). |
-| `name` | no | `default` | Name for the new AMI. |
-| `description` | no | `""` | Description for the new AMI. |
-| `encrypted` | no | `false` | Encrypt destination EBS snapshots. |
-| `kms_key_id` | no | | KMS key ID/ARN/alias for encryption; account default EBS CMK if omitted when `encrypted=true`. |
-| `copy_image_tags` | no | `false` | Also copy tags from the source AMI. |
-| `tags` | no | | Tags to apply to the new AMI. |
-| `tag_equality` | no | `false` | If `true`, skip copy when a destination AMI already has the same `tags` (requires `tags`). |
-| `wait` | no | `false` | Wait until the AMI is `available`. |
-| `wait_timeout` | no | `600` | Seconds to wait when `wait=true`. |
-
-Supports check mode (`ansible-playbook --check`).
-
-#### Examples
-
-Basic copy and wait for availability:
-
-```yaml
-- name: Copy AMI to us-west-2
-  infra.ado.ec2_ami_copy:
-    source_region: us-east-1
-    region: us-west-2
-    source_image_id: ami-0123456789abcdef0
-    name: my-app-image
-    wait: true
-  register: copied_ami
-
-- name: Show new AMI ID
-  ansible.builtin.debug:
-    var: copied_ami.image_id
-```
-
-Encrypted, tagged, idempotent copy (safe to re-run):
-
-```yaml
-- name: Copy AMI with encryption and tag-based idempotency
-  infra.ado.ec2_ami_copy:
-    source_region: us-east-1
-    region: eu-west-1
-    source_image_id: ami-0123456789abcdef0
-    name: my-app-image
-    description: "Promoted golden image"
-    encrypted: true
-    kms_key_id: alias/aws/ebs
-    tags:
-      Name: my-app-image
-      Environment: prod
-    tag_equality: true
-    wait: true
-    wait_timeout: 1200
-  register: copied_ami
-```
-
-Using an AWS named profile:
-
-```yaml
-- name: Copy AMI with a named profile
-  infra.ado.ec2_ami_copy:
-    profile: my-aws-profile
-    source_region: us-east-1
-    region: us-west-2
-    source_image_id: "{{ source_ami_id }}"
-    name: "{{ ami_name }}"
-    wait: true
-```
-
-#### Return values
-
-| Key | Description |
+| Module | Description |
 | --- | --- |
-| `image_id` | AMI ID of the copied AMI, or the existing match when `tag_equality` skips the copy. |
-| `changed` | `true` when a new copy was started; `false` when an existing AMI was reused. |
+| [`infra.ado.ec2_ami_copy`](plugins/modules/ec2_ami_copy/README.md) | Copy an AWS AMI from one region to another. |
 
 ## Role documentation
 
@@ -313,7 +205,7 @@ From the collection root:
 
 ```bash
 cd /path/to/your/git/checkout/infra.ado
-ansible-galaxy collection install . --force -p ~/.ansible/collections
+ansible-galaxy collection install . --force --no-deps -p ~/.ansible/collections
 ansible-galaxy collection install ansible.posix --force -p ~/.ansible/collections
 ```
 

--- a/changelogs/fragments/ec2_ami_copy.yml
+++ b/changelogs/fragments/ec2_ami_copy.yml
@@ -12,8 +12,18 @@ bugfixes:
     ci - Install the local collection with ``--no-deps`` in Molecule jobs so
     ``galaxy.yml`` runtime dependencies are not resolved from Galaxy during
     role scenario runs.
+  - >-
+    ci - Skip Ansible 2.16 and ``py3.12-milestone`` tox-ansible sanity/unit
+    matrix entries; ``amazon.aws`` requires Ansible ``>=2.17`` and current
+    ansible-core milestone requires Python ``>=3.13``.
+breaking_changes:
+  - >-
+    Dropped Ansible 2.16 support (EOL). ``meta/runtime.yml``
+    ``requires_ansible`` is now ``>=2.17.0``, matching CI and the
+    ``amazon.aws`` dependency.
 doc_changes:
   - >-
-    README - Documented modules alongside roles; each module keeps detailed
-    usage docs in its own README under ``plugins/modules/<module>/README.md``
-    (starting with ``infra.ado.ec2_ami_copy``).
+    README - Documented modules alongside roles; detailed module usage lives
+    under ``docs/modules/``.
+  - >-
+    README / docs - Ansible version compatibility updated to ``>=2.17.0``.

--- a/changelogs/fragments/ec2_ami_copy.yml
+++ b/changelogs/fragments/ec2_ami_copy.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - >-
+    infra.ado.ec2_ami_copy - Added module to copy an AWS AMI between regions
+    with wait, encryption, optional source-tag copy, and tag-based idempotency.
+doc_changes:
+  - >-
+    README - Documented modules alongside roles, including end-user guidance
+    for ``infra.ado.ec2_ami_copy`` (requirements, parameters, examples, and
+    return values).

--- a/changelogs/fragments/ec2_ami_copy.yml
+++ b/changelogs/fragments/ec2_ami_copy.yml
@@ -3,8 +3,17 @@ minor_changes:
   - >-
     infra.ado.ec2_ami_copy - Added module to copy an AWS AMI between regions
     with wait, encryption, optional source-tag copy, and tag-based idempotency.
+bugfixes:
+  - >-
+    infra.ado.ec2_ami_copy - Declare ``amazon.aws`` as a collection dependency
+    and fix module documentation metadata so ansible-test validate-modules
+    passes.
+  - >-
+    ci - Install the local collection with ``--no-deps`` in Molecule jobs so
+    ``galaxy.yml`` runtime dependencies are not resolved from Galaxy during
+    role scenario runs.
 doc_changes:
   - >-
-    README - Documented modules alongside roles, including end-user guidance
-    for ``infra.ado.ec2_ami_copy`` (requirements, parameters, examples, and
-    return values).
+    README - Documented modules alongside roles; each module keeps detailed
+    usage docs in its own README under ``plugins/modules/<module>/README.md``
+    (starting with ``infra.ado.ec2_ami_copy``).

--- a/docs/ENGINEERING_STANDARDS.md
+++ b/docs/ENGINEERING_STANDARDS.md
@@ -1,0 +1,7 @@
+# Engineering Standards
+
+ADO Engineering Standards live in the documentation repository:
+
+**https://github.com/Automation-Development-Office/documentation**
+
+Start here: [engineering-standards/README.md](https://github.com/Automation-Development-Office/documentation/blob/main/engineering-standards/README.md)

--- a/docs/collections/infra/ado/index.rst
+++ b/docs/collections/infra/ado/index.rst
@@ -24,7 +24,7 @@ your collection description
 
 **Supported ansible-core versions:**
 
-* 2.16.0 or newer
+* 2.17.0 or newer
 
 .. ansible-links::
 

--- a/docs/modules/ec2_ami_copy.md
+++ b/docs/modules/ec2_ami_copy.md
@@ -4,11 +4,11 @@ Copy an Amazon Machine Image (AMI) from a source AWS region into a destination
 region. Returns the new AMI ID. Designed for environments that have
 `amazon.aws` available but **not** `community.aws`.
 
-Module source: [`../ec2_ami_copy.py`](../ec2_ami_copy.py)
+Module source: [`plugins/modules/ec2_ami_copy.py`](../../plugins/modules/ec2_ami_copy.py)
 
 ## Requirements
 
-- Ansible `>=2.16.0`
+- Ansible `>=2.17.0` (required by the `amazon.aws` dependency)
 - Collection dependency: [`amazon.aws`](https://docs.ansible.com/ansible/latest/collections/amazon/aws/index.html)
   `>=8.0.0` (declared in `galaxy.yml`; provides AWS authentication helpers)
 - Python packages on the controller / execution environment: `boto3`, `botocore`
@@ -35,20 +35,20 @@ Use the standard `amazon.aws` credential options (`access_key`, `secret_key`,
 
 ## Parameters
 
-| Parameter | Required | Default | Description |
-| --- | --- | --- | --- |
-| `source_region` | yes | | Source AWS region of the AMI. |
-| `source_image_id` | yes | | AMI ID in the source region. |
-| `region` | yes* | | Destination AWS region (*via `amazon.aws` region options / env). |
-| `name` | no | `default` | Name for the new AMI. |
-| `description` | no | `""` | Description for the new AMI. |
-| `encrypted` | no | `false` | Encrypt destination EBS snapshots. |
-| `kms_key_id` | no | | KMS key ID/ARN/alias for encryption; account default EBS CMK if omitted when `encrypted=true`. |
-| `copy_image_tags` | no | `false` | Also copy tags from the source AMI. |
-| `tags` | no | | Tags to apply to the new AMI. |
-| `tag_equality` | no | `false` | If `true`, skip copy when a destination AMI already has the same `tags` (requires `tags`). |
-| `wait` | no | `false` | Wait until the AMI is `available`. |
-| `wait_timeout` | no | `600` | Seconds to wait when `wait=true`. |
+| Parameter         | Required | Default   | Description                                                                                    |
+| ----------------- | -------- | --------- | ---------------------------------------------------------------------------------------------- |
+| `source_region`   | yes      |           | Source AWS region of the AMI.                                                                  |
+| `source_image_id` | yes      |           | AMI ID in the source region.                                                                   |
+| `region`          | yes\*    |           | Destination AWS region (\*via `amazon.aws` region options / env).                              |
+| `name`            | no       | `default` | Name for the new AMI.                                                                          |
+| `description`     | no       | `""`      | Description for the new AMI.                                                                   |
+| `encrypted`       | no       | `false`   | Encrypt destination EBS snapshots.                                                             |
+| `kms_key_id`      | no       |           | KMS key ID/ARN/alias for encryption; account default EBS CMK if omitted when `encrypted=true`. |
+| `copy_image_tags` | no       | `false`   | Also copy tags from the source AMI.                                                            |
+| `tags`            | no       |           | Tags to apply to the new AMI.                                                                  |
+| `tag_equality`    | no       | `false`   | If `true`, skip copy when a destination AMI already has the same `tags` (requires `tags`).     |
+| `wait`            | no       | `false`   | Wait until the AMI is `available`.                                                             |
+| `wait_timeout`    | no       | `600`     | Seconds to wait when `wait=true`.                                                              |
 
 Supports check mode (`ansible-playbook --check`).
 
@@ -107,7 +107,7 @@ Using an AWS named profile:
 
 ## Return values
 
-| Key | Description |
-| --- | --- |
+| Key        | Description                                                                         |
+| ---------- | ----------------------------------------------------------------------------------- |
 | `image_id` | AMI ID of the copied AMI, or the existing match when `tag_equality` skips the copy. |
-| `changed` | `true` when a new copy was started; `false` when an existing AMI was reused. |
+| `changed`  | `true` when a new copy was started; `false` when an existing AMI was reused.        |

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,10 +19,11 @@ tags:
   - openshift
   - rhel
   - satellite
-# Runtime collections are installed by the execution environment/container.
-# Keeping this empty lets offline local artifact installs use the already
-# bundled collection tarballs instead of trying to resolve Galaxy dependencies.
-dependencies: {}
+# amazon.aws is required by infra.ado.ec2_ami_copy (AnsibleAWSModule / doc
+# fragments). Other runtime collections remain EE/container-bundled so offline
+# artifact installs are not forced to resolve them from Galaxy.
+dependencies:
+  amazon.aws: ">=8.0.0"
 
 repository: https://github.com/automation-development-office/ado
 documentation: >-

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.16.0"
+requires_ansible: ">=2.17.0"

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -7,7 +7,7 @@
 
 """Copy an AWS AMI from one region to another."""
 
-from __future__ import absolute_import, annotations, division, print_function
+from __future__ import absolute_import, division, print_function
 
 
 __metaclass__ = type

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -22,8 +22,8 @@ description:
   - Copies an Amazon Machine Image (AMI) from a source region
     to the destination region selected by O(region).
   - Returns the new AMI ID in the destination region.
-  - This module depends on the C(amazon.aws) collection for AWS
-    authentication helpers and does not require C(community.aws).
+  - This module requires the C(amazon.aws) collection for AWS authentication
+    helpers and does not require C(community.aws).
 options:
   source_region:
     description:
@@ -91,7 +91,7 @@ options:
     type: bool
     default: false
 author:
-  - Automation Development Office
+  - Automation Development Office (@Automation-Development-Office)
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -99,6 +99,7 @@ extends_documentation_fragment:
 requirements:
   - boto3
   - botocore
+  - amazon.aws
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/ec2_ami_copy.py
+++ b/plugins/modules/ec2_ami_copy.py
@@ -1,0 +1,299 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the infra.ado collection
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Copy an AWS AMI from one region to another."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+---
+module: ec2_ami_copy
+version_added: 1.1.0
+short_description: Copy an AMI between AWS regions
+description:
+  - Copies an Amazon Machine Image (AMI) from a source region
+    to the destination region selected by O(region).
+  - Returns the new AMI ID in the destination region.
+  - This module depends on the C(amazon.aws) collection for AWS
+    authentication helpers and does not require C(community.aws).
+options:
+  source_region:
+    description:
+      - The AWS region that currently holds the source AMI.
+    required: true
+    type: str
+  source_image_id:
+    description:
+      - The AMI ID in O(source_region) to copy.
+    required: true
+    type: str
+  name:
+    description:
+      - Name for the new AMI in the destination region.
+    type: str
+    default: default
+  description:
+    description:
+      - Optional description for the new AMI.
+    type: str
+    default: ""
+  encrypted:
+    description:
+      - Whether destination EBS snapshots of the copied AMI
+        should be encrypted.
+    type: bool
+    default: false
+  kms_key_id:
+    description:
+      - KMS key ID or ARN used to encrypt destination snapshots.
+      - When omitted and O(encrypted=true), uses the account
+        default EBS CMK.
+    type: str
+  copy_image_tags:
+    description:
+      - Copy tags from the source AMI to the new AMI.
+    type: bool
+    default: false
+  wait:
+    description:
+      - Wait until the copied AMI reaches state V(available)
+        before returning.
+    type: bool
+    default: false
+  wait_timeout:
+    description:
+      - Seconds to wait for the AMI to become available when
+        O(wait=true).
+    type: int
+    default: 600
+  tags:
+    description:
+      - Tags to apply to the new AMI in the destination region.
+      - When O(tag_equality=true), these tags are also used to
+        detect an existing matching AMI and skip a duplicate copy.
+    type: dict
+  tag_equality:
+    description:
+      - If V(true), look for an existing AMI in the destination
+        region whose tags match O(tags) exactly (plus state
+        V(available) or V(pending)).
+      - When a match is found, return that AMI ID without
+        copying again.
+      - Requires O(tags) to be set.
+    type: bool
+    default: false
+author:
+  - Automation Development Office
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.boto3
+requirements:
+  - boto3
+  - botocore
+"""
+
+EXAMPLES = r"""
+- name: Copy an AMI to another region
+  infra.ado.ec2_ami_copy:
+    source_region: us-east-1
+    region: us-west-2
+    source_image_id: ami-0123456789abcdef0
+    name: my-app-image
+    wait: true
+  register: copied_ami
+
+- name: Encrypted AMI copy with tags (idempotent via tag_equality)
+  infra.ado.ec2_ami_copy:
+    source_region: us-east-1
+    region: eu-west-1
+    source_image_id: ami-0123456789abcdef0
+    name: my-app-image
+    encrypted: true
+    kms_key_id: alias/aws/ebs
+    tags:
+      Name: my-app-image
+      Environment: prod
+    tag_equality: true
+    wait: true
+    wait_timeout: 1200
+"""
+
+RETURN = r"""
+image_id:
+  description: AMI ID of the copied (or matched existing) AMI.
+  returned: always
+  type: str
+  sample: ami-0abcdef1234567890
+changed:
+  description: Whether a new AMI copy was started.
+  returned: always
+  type: bool
+"""
+
+from typing import Any, Optional
+
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError, WaiterError
+except ImportError:
+    pass  # Caught by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils import modules as aws_modules
+from ansible_collections.amazon.aws.plugins.module_utils import tagging as aws_tagging
+
+
+AnsibleAWSModule = aws_modules.AnsibleAWSModule
+ansible_dict_to_boto3_tag_list = aws_tagging.ansible_dict_to_boto3_tag_list
+
+
+def find_existing_image(ec2: Any, tags: dict) -> Optional[dict]:
+    """Return first destination AMI matching all provided tags."""
+    filters = [{"Name": f"tag:{key}", "Values": [value]} for key, value in tags.items()]
+    filters.append(
+        {"Name": "state", "Values": ["available", "pending"]},
+    )
+    response = ec2.describe_images(Filters=filters)
+    images = response.get("Images") or []
+    if not images:
+        return None
+    return images[0]
+
+
+def build_copy_params(params: dict) -> dict:
+    """Build boto3 CopyImage kwargs from module params."""
+    copy_params = {
+        "SourceRegion": params["source_region"],
+        "SourceImageId": params["source_image_id"],
+        "Name": params["name"],
+        "Description": params.get("description") or "",
+        "Encrypted": params.get("encrypted", False),
+        "CopyImageTags": params.get("copy_image_tags", False),
+    }
+    if params.get("kms_key_id"):
+        copy_params["KmsKeyId"] = params["kms_key_id"]
+
+    tags = params.get("tags") or {}
+    if tags:
+        copy_params["TagSpecifications"] = [
+            {
+                "ResourceType": "image",
+                "Tags": ansible_dict_to_boto3_tag_list(tags),
+            },
+        ]
+    return copy_params
+
+
+def wait_for_image(ec2: Any, image_id: str, wait_timeout: int) -> None:
+    """Wait until the AMI is available."""
+    delay = 15
+    max_attempts = max(1, wait_timeout // delay)
+    ec2.get_waiter("image_available").wait(
+        ImageIds=[image_id],
+        WaiterConfig={"Delay": delay, "MaxAttempts": max_attempts},
+    )
+
+
+def copy_image(module: AnsibleAWSModule, ec2: Any) -> None:
+    """Copy an AMI into the destination region."""
+    params = module.params
+    tags = params.get("tags") or {}
+    image = None
+    changed = False
+
+    if params.get("tag_equality"):
+        if not tags:
+            module.fail_json(
+                msg="tag_equality=true requires tags to be set",
+            )
+        try:
+            image = find_existing_image(ec2, tags)
+        except (BotoCoreError, ClientError) as exc:
+            module.fail_json_aws(
+                exc,
+                msg="Could not search for an existing AMI",
+            )
+
+    if image is None:
+        if module.check_mode:
+            module.exit_json(
+                changed=True,
+                image_id="ami-xxxxxxxxxxxxxxxxx",
+                msg="AMI would be copied",
+            )
+
+        copy_params = build_copy_params(params)
+        try:
+            image = ec2.copy_image(**copy_params)
+            changed = True
+        except (BotoCoreError, ClientError) as exc:
+            module.fail_json_aws(exc, msg="Could not copy AMI")
+    elif module.check_mode:
+        result = camel_dict_to_snake_dict(image)
+        result["image_id"] = image.get("ImageId")
+        module.exit_json(changed=False, **result)
+
+    image_id = image.get("ImageId")
+    if not image_id:
+        module.fail_json(
+            msg="AMI copy response did not include ImageId",
+        )
+
+    if params.get("wait"):
+        try:
+            wait_for_image(
+                ec2,
+                image_id,
+                params.get("wait_timeout") or 600,
+            )
+        except WaiterError as exc:
+            module.fail_json_aws(
+                exc,
+                msg=("An error occurred waiting for the image " "to become available"),
+            )
+        except (BotoCoreError, ClientError) as exc:
+            module.fail_json_aws(
+                exc,
+                msg="Could not wait for AMI availability",
+            )
+
+    result = camel_dict_to_snake_dict(image)
+    result["image_id"] = image_id
+    module.exit_json(changed=changed, **result)
+
+
+def main() -> None:
+    """Module entry point."""
+    argument_spec = dict(
+        source_region=dict(type="str", required=True),
+        source_image_id=dict(type="str", required=True),
+        name=dict(type="str", default="default"),
+        description=dict(type="str", default=""),
+        encrypted=dict(type="bool", default=False),
+        kms_key_id=dict(type="str"),
+        copy_image_tags=dict(type="bool", default=False),
+        wait=dict(type="bool", default=False),
+        wait_timeout=dict(type="int", default=600),
+        tags=dict(type="dict"),
+        tag_equality=dict(type="bool", default=False),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    ec2 = module.client("ec2")
+    copy_image(module, ec2)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ec2_ami_copy/README.md
+++ b/plugins/modules/ec2_ami_copy/README.md
@@ -1,0 +1,113 @@
+# infra.ado.ec2_ami_copy
+
+Copy an Amazon Machine Image (AMI) from a source AWS region into a destination
+region. Returns the new AMI ID. Designed for environments that have
+`amazon.aws` available but **not** `community.aws`.
+
+Module source: [`../ec2_ami_copy.py`](../ec2_ami_copy.py)
+
+## Requirements
+
+- Ansible `>=2.16.0`
+- Collection dependency: [`amazon.aws`](https://docs.ansible.com/ansible/latest/collections/amazon/aws/index.html)
+  `>=8.0.0` (declared in `galaxy.yml`; provides AWS authentication helpers)
+- Python packages on the controller / execution environment: `boto3`, `botocore`
+- IAM permissions in both regions to describe images, copy images, create tags,
+  and (when encrypting) use the target KMS key
+
+Installing this collection from Galaxy also pulls in `amazon.aws`. For offline
+or EE builds, ensure `amazon.aws` is already bundled (see
+`collections/requirements.yml`).
+
+```yaml
+collections:
+  - name: infra.ado
+```
+
+## Authentication and region
+
+Use the standard `amazon.aws` credential options (`access_key`, `secret_key`,
+`session_token`, `profile`, environment variables, or instance/role credentials).
+
+- `source_region` — region that currently holds the AMI to copy
+- `region` — destination region where the new AMI is created (from the
+  `amazon.aws` region fragment)
+
+## Parameters
+
+| Parameter | Required | Default | Description |
+| --- | --- | --- | --- |
+| `source_region` | yes | | Source AWS region of the AMI. |
+| `source_image_id` | yes | | AMI ID in the source region. |
+| `region` | yes* | | Destination AWS region (*via `amazon.aws` region options / env). |
+| `name` | no | `default` | Name for the new AMI. |
+| `description` | no | `""` | Description for the new AMI. |
+| `encrypted` | no | `false` | Encrypt destination EBS snapshots. |
+| `kms_key_id` | no | | KMS key ID/ARN/alias for encryption; account default EBS CMK if omitted when `encrypted=true`. |
+| `copy_image_tags` | no | `false` | Also copy tags from the source AMI. |
+| `tags` | no | | Tags to apply to the new AMI. |
+| `tag_equality` | no | `false` | If `true`, skip copy when a destination AMI already has the same `tags` (requires `tags`). |
+| `wait` | no | `false` | Wait until the AMI is `available`. |
+| `wait_timeout` | no | `600` | Seconds to wait when `wait=true`. |
+
+Supports check mode (`ansible-playbook --check`).
+
+## Examples
+
+Basic copy and wait for availability:
+
+```yaml
+- name: Copy AMI to us-west-2
+  infra.ado.ec2_ami_copy:
+    source_region: us-east-1
+    region: us-west-2
+    source_image_id: ami-0123456789abcdef0
+    name: my-app-image
+    wait: true
+  register: copied_ami
+
+- name: Show new AMI ID
+  ansible.builtin.debug:
+    var: copied_ami.image_id
+```
+
+Encrypted, tagged, idempotent copy (safe to re-run):
+
+```yaml
+- name: Copy AMI with encryption and tag-based idempotency
+  infra.ado.ec2_ami_copy:
+    source_region: us-east-1
+    region: eu-west-1
+    source_image_id: ami-0123456789abcdef0
+    name: my-app-image
+    description: "Promoted golden image"
+    encrypted: true
+    kms_key_id: alias/aws/ebs
+    tags:
+      Name: my-app-image
+      Environment: prod
+    tag_equality: true
+    wait: true
+    wait_timeout: 1200
+  register: copied_ami
+```
+
+Using an AWS named profile:
+
+```yaml
+- name: Copy AMI with a named profile
+  infra.ado.ec2_ami_copy:
+    profile: my-aws-profile
+    source_region: us-east-1
+    region: us-west-2
+    source_image_id: "{{ source_ami_id }}"
+    name: "{{ ami_name }}"
+    wait: true
+```
+
+## Return values
+
+| Key | Description |
+| --- | --- |
+| `image_id` | AMI ID of the copied AMI, or the existing match when `tag_equality` skips the copy. |
+| `changed` | `true` when a new copy was started; `false` when an existing AMI was reused. |

--- a/tests/unit/plugins/modules/test_ec2_ami_copy.py
+++ b/tests/unit/plugins/modules/test_ec2_ami_copy.py
@@ -1,6 +1,9 @@
 """Unit tests for infra.ado.ec2_ami_copy helpers."""
 
-from __future__ import annotations
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
 
 import importlib.util
 import sys

--- a/tests/unit/plugins/modules/test_ec2_ami_copy.py
+++ b/tests/unit/plugins/modules/test_ec2_ami_copy.py
@@ -1,0 +1,217 @@
+"""Unit tests for infra.ado.ec2_ami_copy helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+pytest.importorskip("botocore")
+pytest.importorskip("boto3")
+pytest.importorskip(
+    "ansible_collections.amazon.aws.plugins.module_utils.modules",
+)
+
+_MODULE_PATH = Path(__file__).resolve().parents[4] / "plugins" / "modules" / "ec2_ami_copy.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "ec2_ami_copy",
+    _MODULE_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+ami_copy = importlib.util.module_from_spec(_SPEC)
+sys.modules["ec2_ami_copy"] = ami_copy
+_SPEC.loader.exec_module(ami_copy)
+
+
+def test_build_copy_params_minimal() -> None:
+    """Copy params include required CopyImage fields."""
+    params = {
+        "source_region": "us-east-1",
+        "source_image_id": "ami-abc",
+        "name": "copied",
+        "description": "",
+        "encrypted": False,
+        "copy_image_tags": False,
+        "tags": None,
+    }
+    result = ami_copy.build_copy_params(params)
+    assert result == {
+        "SourceRegion": "us-east-1",
+        "SourceImageId": "ami-abc",
+        "Name": "copied",
+        "Description": "",
+        "Encrypted": False,
+        "CopyImageTags": False,
+    }
+
+
+def test_build_copy_params_with_encryption_and_tags() -> None:
+    """Encryption and tags map to boto3 CopyImage kwargs."""
+    params = {
+        "source_region": "us-east-1",
+        "source_image_id": "ami-abc",
+        "name": "copied",
+        "description": "patched",
+        "encrypted": True,
+        "kms_key_id": "alias/aws/ebs",
+        "copy_image_tags": True,
+        "tags": {"Name": "copied", "Env": "prod"},
+    }
+    result = ami_copy.build_copy_params(params)
+    assert result["Encrypted"] is True
+    assert result["KmsKeyId"] == "alias/aws/ebs"
+    assert result["CopyImageTags"] is True
+    assert result["TagSpecifications"][0]["ResourceType"] == "image"
+    tags = result["TagSpecifications"][0]["Tags"]
+    tag_pairs = {tag["Key"]: tag["Value"] for tag in tags}
+    assert tag_pairs == {"Name": "copied", "Env": "prod"}
+
+
+def test_find_existing_image_returns_first_match() -> None:
+    """Existing AMI lookup returns the first filtered image."""
+    ec2 = MagicMock()
+    ec2.describe_images.return_value = {
+        "Images": [
+            {"ImageId": "ami-existing"},
+            {"ImageId": "ami-other"},
+        ],
+    }
+    found = ami_copy.find_existing_image(ec2, {"Name": "copied"})
+    assert found == {"ImageId": "ami-existing"}
+    filters = ec2.describe_images.call_args.kwargs["Filters"]
+    assert {"Name": "tag:Name", "Values": ["copied"]} in filters
+    assert {
+        "Name": "state",
+        "Values": ["available", "pending"],
+    } in filters
+
+
+def test_find_existing_image_returns_none_when_empty() -> None:
+    """Existing AMI lookup returns None when no images match."""
+    ec2 = MagicMock()
+    ec2.describe_images.return_value = {"Images": []}
+    assert ami_copy.find_existing_image(ec2, {"Name": "missing"}) is None
+
+
+def test_wait_for_image_configures_waiter() -> None:
+    """Waiter uses delay/max_attempts derived from wait_timeout."""
+    waiter = MagicMock()
+    ec2 = MagicMock()
+    ec2.get_waiter.return_value = waiter
+
+    ami_copy.wait_for_image(ec2, "ami-123", wait_timeout=60)
+
+    ec2.get_waiter.assert_called_once_with("image_available")
+    waiter.wait.assert_called_once_with(
+        ImageIds=["ami-123"],
+        WaiterConfig={"Delay": 15, "MaxAttempts": 4},
+    )
+
+
+def test_copy_image_skips_when_tag_equality_matches() -> None:
+    """tag_equality returns existing AMI without calling copy_image."""
+    module = MagicMock()
+    module.check_mode = False
+    module.params = {
+        "tag_equality": True,
+        "tags": {"Name": "copied"},
+        "wait": False,
+    }
+    ec2 = MagicMock()
+    ec2.describe_images.return_value = {
+        "Images": [{"ImageId": "ami-existing"}],
+    }
+
+    def _exit_json(**kwargs: Any) -> None:
+        raise SystemExit(kwargs)
+
+    module.exit_json.side_effect = _exit_json
+
+    with pytest.raises(SystemExit) as exc:
+        ami_copy.copy_image(module, ec2)
+
+    result = exc.value.args[0]
+    assert result["changed"] is False
+    assert result["image_id"] == "ami-existing"
+    ec2.copy_image.assert_not_called()
+
+
+def test_copy_image_creates_when_missing() -> None:
+    """A new copy is started when no matching AMI exists."""
+    module = MagicMock()
+    module.check_mode = False
+    module.params = {
+        "source_region": "us-east-1",
+        "source_image_id": "ami-src",
+        "name": "copied",
+        "description": "",
+        "encrypted": False,
+        "copy_image_tags": False,
+        "tag_equality": False,
+        "tags": {"Name": "copied"},
+        "wait": False,
+    }
+    ec2 = MagicMock()
+    ec2.copy_image.return_value = {"ImageId": "ami-new"}
+
+    def _exit_json(**kwargs: Any) -> None:
+        raise SystemExit(kwargs)
+
+    module.exit_json.side_effect = _exit_json
+
+    with pytest.raises(SystemExit) as exc:
+        ami_copy.copy_image(module, ec2)
+
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert result["image_id"] == "ami-new"
+    ec2.copy_image.assert_called_once()
+
+
+def test_copy_image_check_mode_reports_change() -> None:
+    """Check mode reports a pending copy without calling AWS APIs."""
+    module = MagicMock()
+    module.check_mode = True
+    module.params = {
+        "tag_equality": False,
+        "tags": None,
+        "wait": False,
+    }
+    ec2 = MagicMock()
+
+    def _exit_json(**kwargs: Any) -> None:
+        raise SystemExit(kwargs)
+
+    module.exit_json.side_effect = _exit_json
+
+    with pytest.raises(SystemExit) as exc:
+        ami_copy.copy_image(module, ec2)
+
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert result["image_id"].startswith("ami-")
+    ec2.copy_image.assert_not_called()
+
+
+def test_copy_image_requires_tags_for_tag_equality() -> None:
+    """tag_equality without tags fails clearly."""
+    module = MagicMock()
+    module.check_mode = False
+    module.params = {"tag_equality": True, "tags": None}
+    ec2 = MagicMock()
+
+    def _fail_json(**kwargs: Any) -> None:
+        raise SystemExit(kwargs)
+
+    module.fail_json.side_effect = _fail_json
+
+    with pytest.raises(SystemExit) as exc:
+        ami_copy.copy_image(module, ec2)
+
+    assert "tag_equality=true requires tags" in exc.value.args[0]["msg"]

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+botocore

--- a/tox-ansible.ini
+++ b/tox-ansible.ini
@@ -8,4 +8,8 @@ skip =
     2.11
     2.12
     2.13
+    # Ansible 2.16 is EOL; requires_ansible is >=2.17 (also needed by amazon.aws)
+    2.16
+    # ansible milestone currently requires Python >=3.13
     py3.12-devel
+    py3.12-milestone


### PR DESCRIPTION
Add the infra.ado.ec2_ami_copy module for copying AWS AMIs between regions, with optional wait, encryption, source-tag copy, and tag-based idempotency. Update the README to document modules alongside roles, add a changelog fragment, unit tests, test requirements, and a pointer to ADO engineering standards. Also ignore Python bytecode and pytest caches.

## Summary

<!-- Briefly describe what changed and why (1–3 sentences). -->

## Related issues

<!-- Link related work. Examples: Fixes #123, Relates to #456 -->

-

## Type of change

<!-- Mark all that apply. -->

- [x] New or updated collection role
- [ ] New or updated Molecule scenario (`extensions/molecule/`)
- [ ] CI / GitHub Actions workflow
- [x] Scripts or developer tooling
- [ ] Documentation only
- [ ] Bug fix
- [ ] Other (describe below)

## Collection impact

<!-- List the main paths touched so reviewers know where to focus. -->

| Area | Path(s) |
| --- | --- |
| Role(s) | <!-- e.g. roles/satellite_content_view --> |
| Molecule scenario(s) | <!-- e.g. extensions/molecule/integration_satellite_content_view_create --> |
| Other | module to copy an aws ami from one region to another |

## Test plan

<!-- Describe how you validated this change. Check all that apply. -->

- [x] Reviewed diff locally
- [x] `ansible-lint` passes (if Ansible content changed)
- [x] README format check passes (if a role README changed):

  ```bash
  python scripts/verify_readme.py roles/<role>/README.md \
    --template docs/templates/role_readme_format_template.md
  ```
  - [x] Security scan passed if a role was updated

  ```bash
  python3 scripts/security_checks.py roles/<role_name>
  ```

- [x] Simulate CI changelog validation compared to `main` branch
```bash
python3 scripts/validate_changelog.py --ref main
```

- [x] Molecule scenario run (if applicable):

  ```bash
  cd extensions/molecule
  ln -sfn . molecule
  molecule test -s <scenario>
  ```

- [ ] CI checks pass on this PR

**Notes / commands run:**

<!-- Paste relevant command output or manual test steps. -->

## Release notes

Add a changelog fragment under `changelogs/fragments/` when the PR modifies existing
roles, plugins, or modules. New plugins/modules and documentation-only changes do not
require a fragment. Use the `skip-changelog` label to bypass validation when no entry is
needed.

Example fragment (`changelogs/fragments/my-change.yml`):

```yaml
minor_changes:
  - my_role - Added support for example configuration.
```

<!-- Optional user-facing note for a changelog entry. Leave blank if not applicable. -->

-

## Checklist

- [x] Role README follows `docs/templates/role_readme_format_template.md` (for role changes)
- [x] Discussed with the team (for new roles or significant design changes)
- [x] No secrets, credentials, or environment-specific values committed
- [x] Breaking changes or migration steps documented above (if any)
