### PR TITLE
Fix changelog release for amazon.aws doc fragments

### DIFF
--- a/.github/Developers _Guide.md
+++ b/.github/Developers _Guide.md
@@ -503,11 +503,14 @@ accumulated changelog fragments into release notes before the collection tarball
 
 **Behavior:**
 
-1. If the release version is already recorded in `changelogs/changelog.yaml`, render outputs only
-2. Otherwise, if `origin/main` already contains the release entry, sync those changelog files into the build workspace
-3. Otherwise, if fragments exist under `changelogs/fragments/`, run `antsibull-changelog release --version <version>`
-4. Render `CHANGELOG.rst` and per-release notes with `antsibull-changelog generate`
-5. Consumed fragments are removed in the runner workspace (`keep_fragments: false` in [`changelogs/config.yaml`](../changelogs/config.yaml))
+1. Install collections declared in `galaxy.yml` `dependencies` so
+   `antsibull-changelog` can resolve external `extends_documentation_fragment`
+   references (for example `amazon.aws` used by `infra.ado.ec2_ami_copy`)
+2. If the release version is already recorded in `changelogs/changelog.yaml`, render outputs only
+3. Otherwise, if `origin/main` already contains the release entry, sync those changelog files into the build workspace
+4. Otherwise, if fragments exist under `changelogs/fragments/`, run `antsibull-changelog release --version <version>`
+5. Render `CHANGELOG.rst` and per-release notes with `antsibull-changelog generate`
+6. Consumed fragments are removed in the runner workspace (`keep_fragments: false` in [`changelogs/config.yaml`](../changelogs/config.yaml))
 
 Set `consume_fragments: false` to sync an already-compiled changelog without deleting fragments.
 

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -47,6 +47,36 @@ runs:
         pip install antsibull-changelog pyyaml ansible-core semantic-version
         CHECK_VERSION="$VERSION" python3 "${GITHUB_WORKSPACE}/scripts/validate_release_version.py"
 
+        # Modules may extend doc_fragments from galaxy.yml dependencies (for
+        # example amazon.aws). antsibull-changelog must resolve those fragments
+        # when scanning plugins during release.
+        COLLECTIONS_PATH="${RUNNER_TEMP:-/tmp}/changelog-collections"
+        mkdir -p "$COLLECTIONS_PATH"
+        REQ_FILE="$(mktemp)"
+        DEP_COUNT="$(
+          REQ_FILE="$REQ_FILE" python3 -c '
+        import os
+        import pathlib
+        import yaml
+
+        galaxy = yaml.safe_load(pathlib.Path("galaxy.yml").read_text(encoding="utf-8")) or {}
+        deps = galaxy.get("dependencies") or {}
+        collections = [
+            {"name": name, "version": version} for name, version in deps.items()
+        ]
+        pathlib.Path(os.environ["REQ_FILE"]).write_text(
+            yaml.safe_dump({"collections": collections}, sort_keys=False),
+            encoding="utf-8",
+        )
+        print(len(collections))
+        '
+        )"
+        if [ "$DEP_COUNT" -gt 0 ]; then
+          echo "Installing ${DEP_COUNT} galaxy.yml dependenc(y/ies) for changelog doc fragments."
+          ansible-galaxy collection install -r "$REQ_FILE" -p "$COLLECTIONS_PATH"
+        fi
+        export ANSIBLE_COLLECTIONS_PATH="$COLLECTIONS_PATH"
+
         release_exists() {
           CHECK_VERSION="$VERSION" python3 -c '
         import os

--- a/.github/actions/preview-changelog/action.yml
+++ b/.github/actions/preview-changelog/action.yml
@@ -60,6 +60,34 @@ runs:
         pip install antsibull-changelog pyyaml ansible-core semantic-version
         CHECK_VERSION="$VERSION" python3 "${GITHUB_WORKSPACE}/scripts/validate_release_version.py"
 
+        # Same as generate-changelog: resolve galaxy.yml doc_fragment deps.
+        COLLECTIONS_PATH="${RUNNER_TEMP:-/tmp}/changelog-collections"
+        mkdir -p "$COLLECTIONS_PATH"
+        REQ_FILE="$(mktemp)"
+        DEP_COUNT="$(
+          REQ_FILE="$REQ_FILE" python3 -c '
+        import os
+        import pathlib
+        import yaml
+
+        galaxy = yaml.safe_load(pathlib.Path("galaxy.yml").read_text(encoding="utf-8")) or {}
+        deps = galaxy.get("dependencies") or {}
+        collections = [
+            {"name": name, "version": version} for name, version in deps.items()
+        ]
+        pathlib.Path(os.environ["REQ_FILE"]).write_text(
+            yaml.safe_dump({"collections": collections}, sort_keys=False),
+            encoding="utf-8",
+        )
+        print(len(collections))
+        '
+        )"
+        if [ "$DEP_COUNT" -gt 0 ]; then
+          echo "Installing ${DEP_COUNT} galaxy.yml dependenc(y/ies) for changelog doc fragments."
+          ansible-galaxy collection install -r "$REQ_FILE" -p "$COLLECTIONS_PATH"
+        fi
+        export ANSIBLE_COLLECTIONS_PATH="$COLLECTIONS_PATH"
+
         fragments_present() {
           shopt -s nullglob
           local files=(changelogs/fragments/*.yml changelogs/fragments/*.yaml)

--- a/changelogs/fragments/ci-changelog-galaxy-deps.yml
+++ b/changelogs/fragments/ci-changelog-galaxy-deps.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - >-
+    ci - Install ``galaxy.yml`` collection dependencies before
+    ``antsibull-changelog release`` so modules that extend external
+    doc fragments (for example ``amazon.aws``) can be parsed during
+    release builds.


### PR DESCRIPTION
## Summary
- Install `galaxy.yml` collection dependencies before `antsibull-changelog release` in generate/preview changelog actions
- Fixes release build failure when scanning `infra.ado.ec2_ami_copy`, which extends `amazon.aws` doc fragments
- Documents the dependency install step in the Developers Guide

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, changelog generation can resolve `amazon.aws` doc fragments used by `infra.ado.ec2_ami_copy`


Made with [Cursor](https://cursor.com)